### PR TITLE
All Day date formatting does not include TZ.

### DIFF
--- a/lib/ical-generator.js
+++ b/lib/ical-generator.js
@@ -124,9 +124,9 @@ var a = {
 							s += pad(d.getUTCHours());
 							s += pad(d.getUTCMinutes());
 							s += pad(d.getUTCSeconds());
+							s += 'Z';
 						}
 
-						s += 'Z';
 						return s;
 					}
 


### PR DESCRIPTION
This was a nasty one, right now all day events totally break in iCalendar. I'm now depending on this fix so the quicker a new push goes up to npm the more happy I'll be :)
