### PR TITLE
Add charset in the returned Content-Type header

### DIFF
--- a/lib/ical-generator.js
+++ b/lib/ical-generator.js
@@ -219,7 +219,7 @@ var a = {
 					}
 
 					res.writeHead(200, {
-						'Content-Type': 'text/calendar',
+						'Content-Type': 'text/calendar; charset=utf-8',
 						'Content-Disposition': 'attachment; filename="calendar.ics"'
 					});
 					res.end(cal.generated);


### PR DESCRIPTION
Added `charset=utf-8` to content type. Otherwise Google Calendar doesn't render events with unicode strings properly. See https://github.com/webuildsg/webuild/issues/167