### PR TITLE
Fix CRLF escaping

### DIFF
--- a/lib/_tools.js
+++ b/lib/_tools.js
@@ -28,13 +28,9 @@ module.exports.formatDate = function formatDate(d, dateonly, floating) {
 };
 
 module.exports.escape = function escape(str) {
-    return str.replace(/[\\;,\n"]/g, function(match) {
-        if(match === '\n') {
-            return '\\n';
-        }
-
+    return str.replace(/[\\;,"]/g, function(match) {
         return '\\' + match;
-    });
+    }).replace(/(?:\r\n|\r|\n)/g, '\\n');
 };
 
 module.exports.duration = function duration(seconds) {

--- a/test/test_0.2.x.js
+++ b/test/test_0.2.x.js
@@ -789,6 +789,18 @@ describe('ical-generator 0.2.x / ICalCalendar', function() {
                 event.summary('Example Event II');
                 assert.ok(str !== cal.toString());
             });
+
+            it('should escape CR/CRLF line breaks', function() {
+                var cal = ical(),
+                    event = cal.createEvent({
+                        start: new Date(),
+                        end: new Date(new Date().getTime() + 3600000),
+                        summary: 'Example with a\rlinebreak'
+                    }),
+                    str = cal.toString();
+
+                assert.equal(str.indexOf('\rlinebreak'), -1);
+            });
         });
 
         describe('location()', function() {


### PR DESCRIPTION
At the moment if you feed ICalEvent.summary() something with CRLF or CR line breaks in, the LF will be escaped but the CR will not. This normalises line breaks to LF only before escaping them. Test included.

Sorry for previous pull request.  This one has the right base branch I think.