### PR TITLE
Optional end date

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -562,9 +562,6 @@ var ICalEvent = function(_data) {
         if(!data.start) {
             throw 'No value for `start` in ICalEvent #' + data.id + ' given!';
         }
-        if(!data.end) {
-            throw 'No value for `end` in ICalEvent #' + data.id + ' given!';
-        }
 
         // DATE & TIME
         g += 'BEGIN:VEVENT\r\n';
@@ -572,10 +569,14 @@ var ICalEvent = function(_data) {
         g += 'DTSTAMP:' + tools.formatDate(data.stamp) + '\r\n';
         if(data.allDay) {
             g += 'DTSTART;VALUE=DATE:' + tools.formatDate(data.start, true) + '\r\n';
-            g += 'DTEND;VALUE=DATE:' + tools.formatDate(data.end, true) + '\r\n';
+            if (data.end) {
+	            g += 'DTEND;VALUE=DATE:' + tools.formatDate(data.end, true) + '\r\n';
+            }
         } else {
             g += 'DTSTART:' + tools.formatDate(data.start, false, data.floating) + '\r\n';
-            g += 'DTEND:' + tools.formatDate(data.end, false, data.floating) + '\r\n';
+            if (data.end) {
+	            g += 'DTEND:' + tools.formatDate(data.end, false, data.floating) + '\r\n';
+            }
         }
 
         // REPEATING

--- a/test/test_0.2.x.js
+++ b/test/test_0.2.x.js
@@ -257,16 +257,17 @@ describe('ical-generator 0.2.x / ICalCalendar', function() {
             });
 
             it('should throw error when event invalid', function() {
-                var cal = ical(),
+                var file = path.join(__dirname, 'save.ical'),
+                    cal = ical(),
                     e = cal.createEvent();
 
                 assert.throws(function() {
-                    cal.save();
+                    cal.save(file);
                 }, /`start`/);
 
                 e.start(new Date());
                 assert.throws(function() {
-                    cal.save();
+                    cal.save(file);
                 }, /`end`/);
             });
         });
@@ -287,18 +288,19 @@ describe('ical-generator 0.2.x / ICalCalendar', function() {
             });
 
             it('should throw error when event invalid', function() {
-                var cal = ical(),
+                var file = path.join(__dirname, 'save_sync.ical'),
+                    cal = ical(),
                     e = cal.createEvent();
 
                 assert.throws(function() {
                     /*jslint stupid: true */
-                    cal.saveSync();
+                    cal.saveSync(file);
                 }, /`start`/);
 
                 e.start(new Date());
                 assert.throws(function() {
                     /*jslint stupid: true */
-                    cal.saveSync();
+                    cal.saveSync(file);
                 }, /`end`/);
             });
         });

--- a/test/test_0.2.x.js
+++ b/test/test_0.2.x.js
@@ -264,11 +264,6 @@ describe('ical-generator 0.2.x / ICalCalendar', function() {
                 assert.throws(function() {
                     cal.save(file);
                 }, /`start`/);
-
-                e.start(new Date());
-                assert.throws(function() {
-                    cal.save(file);
-                }, /`end`/);
             });
         });
 
@@ -296,12 +291,6 @@ describe('ical-generator 0.2.x / ICalCalendar', function() {
                     /*jslint stupid: true */
                     cal.saveSync(file);
                 }, /`start`/);
-
-                e.start(new Date());
-                assert.throws(function() {
-                    /*jslint stupid: true */
-                    cal.saveSync(file);
-                }, /`end`/);
             });
         });
 


### PR DESCRIPTION
According to the iCal specification DTEND is an optional component of events.  This patch allows this.  Tests updated.  Also see #29