### PR TITLE
Add attendee status needs-action and attendee RSVP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Return a shallow copy of the calendar's options for JSON stringification. Can be
 ```javascript
 var cal = ical(),
     json = JSON.stringify(cal);
-    
+
 // later
 cal = ical(json);
 ```
@@ -356,7 +356,7 @@ Appointment description
 
 #### htmlDescription([_String_ htmlDescription])
 
-Some calendar apps may support HTML descriptions. Like in emails, supported HTML tags and styling is limited. 
+Some calendar apps may support HTML descriptions. Like in emails, supported HTML tags and styling is limited.
 
 
 #### location([_String_ location])
@@ -470,6 +470,9 @@ Use this method to set the attendee's name.
 
 The attendee's email address. An email address is required for every attendee!
 
+#### rsvp([_String_ rsvp])
+
+Set the attendee's RSVP expectation. May be one of the following: `true`, `false`
 
 #### role([_String_ role])
 
@@ -478,7 +481,7 @@ Set the attendee's role, defaults to `REQ-PARTICIPANT`. May be one of the follow
 
 #### status([_String_ status])
 
-Set the attendee's status. May be one of the following: `accepted`, `tentative`, `declined`
+Set the attendee's status. May be one of the following: `accepted`, `tentative`, `declined`, `needs-action` (See [Section 4.2.12](https://tools.ietf.org/html/rfc2445#section-4.2.12))
 
 
 #### type([_String_ type])

--- a/lib/attendee.js
+++ b/lib/attendee.js
@@ -7,7 +7,7 @@
  * @constructor ICalAttendee Attendee
  */
 var ICalAttendee = function(_data, event) {
-    var attributes = ['name', 'email', 'role', 'status', 'type', 'delegatedTo', 'delegatedFrom', 'delegatesFrom', 'delegatesTo'],
+    var attributes = ['name', 'email', 'role', 'rsvp', 'status', 'type', 'delegatedTo', 'delegatedFrom', 'delegatesFrom', 'delegatesTo'],
         vars,
         i,
         data;
@@ -19,7 +19,8 @@ var ICalAttendee = function(_data, event) {
     vars = {
         allowed: {
             role: ['REQ-PARTICIPANT', 'NON-PARTICIPANT'],
-            status: ['ACCEPTED', 'TENTATIVE', 'DECLINED', 'DELEGATED'],
+            rsvp: ['TRUE', 'FALSE'],
+						status: ['ACCEPTED', 'TENTATIVE', 'DECLINED', 'DELEGATED', 'NEEDS-ACTION'], // ref: https://tools.ietf.org/html/rfc2445#section-4.2.12
             type: ['INDIVIDUAL', 'GROUP', 'RESOURCE', 'ROOM', 'UNKNOWN'] // ref: https://tools.ietf.org/html/rfc2445#section-4.2.3
         }
     };
@@ -29,6 +30,7 @@ var ICalAttendee = function(_data, event) {
         email: null,
         status: null,
         role: 'REQ-PARTICIPANT',
+        rsvp: null,
         type: null,
         delegatedTo: null,
         delegatedFrom: null
@@ -37,6 +39,10 @@ var ICalAttendee = function(_data, event) {
 
     function getAllowedRole(str) {
         return getAllowedStringFor('role', str);
+    }
+
+    function getAllowedRSVP(str) {
+        return getAllowedStringFor('rsvp', str);
     }
 
     function getAllowedStatus(str) {
@@ -109,6 +115,27 @@ var ICalAttendee = function(_data, event) {
         }
 
         data.role = getAllowedRole(role);
+        return this;
+    };
+
+
+    /**
+     * Set/Get attendee's RSVP expectation
+     *
+     * @param {String} rsvp
+     * @since 0.2.1
+     * @returns {ICalAttendee|String}
+     */
+    this.rsvp = function(rsvp) {
+        if(rsvp === undefined) {
+            return data.rsvp;
+        }
+        if(!rsvp) {
+            data.rsvp = null;
+            return this;
+        }
+
+        data.rsvp = getAllowedRSVP(rsvp);
         return this;
     };
 
@@ -274,6 +301,11 @@ var ICalAttendee = function(_data, event) {
         // PARTSTAT
         if(data.status) {
             g += ';PARTSTAT=' + data.status;
+        }
+
+        // RSVP
+        if(data.rsvp) {
+            g += ';RSVP=' + data.rsvp;
         }
 
         // DELEGATED-TO

--- a/test/test_0.2.x.js
+++ b/test/test_0.2.x.js
@@ -1766,6 +1766,42 @@ describe('ical-generator 0.2.x / ICalCalendar', function() {
             });
         });
 
+        describe('rsvp()', function() {
+            it('setter should return this', function() {
+                var a = ical().createEvent().createAttendee();
+                assert.deepEqual(a, a.rsvp(null));
+                assert.deepEqual(a, a.rsvp('TRUE'));
+            });
+
+            it('getter should return value', function() {
+                var a = ical().createEvent().createAttendee();
+                assert.equal(a.rsvp(), null);
+                a.rsvp('false');
+                assert.equal(a.rsvp(), 'FALSE');
+                a.rsvp(null);
+                assert.equal(a.rsvp(), null);
+            });
+
+            it('should throw error when method not allowed', function() {
+                var a = ical().createEvent().createAttendee();
+                assert.throws(function() {
+                    a.rsvp('PROBABLY');
+                }, /`rsvp` must be one of the following/);
+            });
+
+            it('should change something', function() {
+                var cal = ical(),
+                    event = cal.createEvent({
+                        start: new Date(),
+                        end: new Date(new Date().getTime() + 3600000),
+                        summary: 'Example Event'
+                    });
+
+                event.createAttendee({email: 'mail@example.com', rsvp: 'true'});
+                assert.ok(cal.toString().indexOf(';RSVP=TRUE') > -1);
+            });
+        });
+
         describe('status()', function() {
             it('setter should return this', function() {
                 var a = ical().createEvent().createAttendee();


### PR DESCRIPTION
This adds the attendee status `NEEDS-ACTION` (See [Section 4.2.12](https://tools.ietf.org/html/rfc2445#section-4.2.12)) and attendee RSVP Expectation. (See [Section 4.2.17](https://tools.ietf.org/html/rfc2445#section-4.2.17))
These allow for ical-generator to create invitations which show accept/reject/maybe options in email clients. This module is currently recommended by the authors of the popular module [nodemailer](https://nodemailer.com/message/calendar-events/) and emailing invitations is a common use case for calendar events.