### PR TITLE
Missing htmlDescription in attributes

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -50,6 +50,7 @@ class ICalEvent {
             'summary',
             'location',
             'description',
+            'htmlDescription',
             'organizer',
             'attendees',
             'alarms',


### PR DESCRIPTION
To fix bug when toString do not return htmlDescription in output