### PR TITLE
Fixed EventData typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ declare module 'ical-generator' {
      * Information used to create calendar events
      */
     interface EventData {
-      start: moment;
+      start: moment.Moment | Date;
       summary: string;
       id?: string;
       uid?: string;


### PR DESCRIPTION
The `start` property is now correctly typed as `moment.Moment | Date`

Fixes #92