### PR TITLE
fix: remove `method` from `ICalEvent`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -196,8 +196,6 @@ declare module 'ical-generator' {
       createCategory(categoryData: CategoryData): ICalCategory;
       categories(): ICalCategory[];
       categories(categories: CategoryData[]): ICalEvent;
-      method(): method;
-      method(method: method): ICalEvent;
       status(): status;
       status(status: status): ICalEvent;
       url(): string;


### PR DESCRIPTION
I haven't seen `method` on `ICalEvent` in the implementation

* Found it because of a bug on our system were someone called this method in the wrong place because of it