### PR TITLE
Fix Attendee field type type to addenteeType

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -95,7 +95,7 @@ declare module 'ical-generator' {
     interface AttendeeData extends PersonData {
       role?: attendeeRole;
       status?: attendeeStatus;
-      type?: attendeeStatus;
+      type?: attendeeType;
       delegatedTo?: ICalAttendee;
       delegatedFrom?: ICalAttendee;
       delegatesTo?: ICalAttendee;


### PR DESCRIPTION
AttendeeData field type is throwing error in typescript application as it is typed to attendeeStatus. Should be typed to attnedeeType