### PR TITLE
Added bySetPos support for repeating events

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ event.repeating({
     byDay: ['su', 'mo'], // repeat only sunday and monday
     byMonth: [1, 2], // repeat only in january und february,
     byMonthDay: [1, 15], // repeat only on the 1st and 15th
+    bySetPos: 3, // repeat every 3rd sunday (will take the first element of the byDay array)
     exclude: [new Date('Dec 25 2013 00:00:00 UTC')] // exclude these dates
 });
 ```

--- a/src/event.js
+++ b/src/event.js
@@ -434,6 +434,18 @@ class ICalEvent {
             });
         }
 
+        if (repeating.bySetPos) {
+            if (!repeating.byDay) {
+                throw '`repeating.bySetPos` must be used along with `repeating.byDay`!';
+            }
+            if(typeof repeating.bySetPos !== 'number' || repeating.bySetPos < -1 || repeating.bySetPos > 4) {
+                throw '`repeating.bySetPos` contains invalid value `' + repeating.bySetPos + '`!';
+            }
+
+            c._data.repeating.byDay = [repeating.byDay[0]];
+            c._data.repeating.bySetPos = repeating.bySetPos;
+        }
+
         if (repeating.exclude) {
             if (!Array.isArray(repeating.exclude)) {
                 repeating.exclude = [repeating.exclude];
@@ -926,6 +938,10 @@ class ICalEvent {
 
             if (this._data.repeating.byMonthDay) {
                 g += ';BYMONTHDAY=' + this._data.repeating.byMonthDay.join(',');
+            }
+
+            if(this._data.repeating.bySetPos) {
+                g += ';BYSETPOS=' + this._data.repeating.bySetPos;
             }
 
             g += '\r\n';

--- a/test/test_event.js
+++ b/test/test_event.js
@@ -704,6 +704,58 @@ describe('ical-generator Event', function () {
             assert.deepEqual(e._data.repeating.byMonthDay, [1, 15]);
         });
 
+        it('should throw error when repeating.bySetPos is not valid', function () {
+            assert.throws(function () {
+                new ICalEvent({
+                    start: moment(),
+                    end: moment(),
+                    summary: 'test',
+                    repeating: {
+                        freq: 'MONTHLY',
+                        interval: 2,
+                        byDay: ['SU'],
+                        bySetPos: 6
+                    }
+                }, new ICalCalendar());
+            }, /`repeating\.bySetPos` contains invalid value `6`/);
+
+            assert.throws(function () {
+                new ICalEvent({
+                    start: moment(),
+                    end: moment(),
+                    summary: 'test',
+                    repeating: {
+                        freq: 'MONTHLY',
+                        interval: 2,
+                        byDay: ['SU'],
+                        bySetPos: 'FOO'
+                    }
+                }, new ICalCalendar());
+            }, /`repeating\.bySetPos` contains invalid value `FOO`/);
+        });
+
+        it('should throw error when repeating.byDay is not present with repeating.bySetPos', function () {
+            assert.throws(function () {
+                new ICalEvent({
+                    start: moment(),
+                    end: moment(),
+                    summary: 'test',
+                    repeating: {
+                        freq: 'MONTHLY',
+                        interval: 2,
+                        bySetPos: 6
+                    }
+                }, new ICalCalendar());
+            }, /`repeating\.bySetPos` must be used along with `repeating\.byDay`/);
+        });
+
+        it('setter should update repeating.bySetPos', function () {
+            const e = new ICalEvent(null, new ICalCalendar());
+
+            e.repeating({freq: 'monthly', byDay: ['SU'], bySetPos: 2});
+            assert.equal(e._data.repeating.bySetPos, 2);
+        });
+
         it('should throw error when repeating.exclude is not valid', function () {
             assert.throws(function () {
                 new ICalEvent({

--- a/test/test_issues.js
+++ b/test/test_issues.js
@@ -36,4 +36,52 @@ describe('Issues', function () {
             assert.ok(str.indexOf('DTSTART;VALUE=DATE:20160501') > -1);
         });
     });
+
+    describe('Issue #123', function () {
+        it('should work with repeating bySetPos', function() {
+            const calendar = ical({
+                domain: 'sebbo.net',
+                prodId: '//superman-industries.com//ical-generator//EN',
+                events: [{
+                    start: new Date('Sun May 01 2016 00:00:00 GMT+0200 (CEST)'),
+                    end: new Date('Sun May 01 2016 02:00:00 GMT+0200 (CEST)'),
+                    summary: 'Example Event',
+                    allDay: true,
+                    repeating: {
+                        freq: 'MONTHLY',
+                        count: 3,
+                        interval: 1,
+                        byDay: ['SU'],
+                        bySetPos: 3
+                    }
+                }]
+            });
+
+            const str = calendar.toString();
+            assert.ok(str.indexOf('RRULE:FREQ=MONTHLY;COUNT=3;INTERVAL=1;BYDAY=SU;BYSETPOS=3') > -1);
+        });
+
+        it('should work with repeating bySetPos by taking the first elemnt of the byDay array', function() {
+            const calendar = ical({
+                domain: 'sebbo.net',
+                prodId: '//superman-industries.com//ical-generator//EN',
+                events: [{
+                    start: new Date('Sun May 01 2016 00:00:00 GMT+0200 (CEST)'),
+                    end: new Date('Sun May 01 2016 02:00:00 GMT+0200 (CEST)'),
+                    summary: 'Example Event',
+                    allDay: true,
+                    repeating: {
+                        freq: 'MONTHLY',
+                        count: 3,
+                        interval: 1,
+                        byDay: ['MO', 'FR'],
+                        bySetPos: 3
+                    }
+                }]
+            });
+
+            const str = calendar.toString();
+            assert.ok(str.indexOf('RRULE:FREQ=MONTHLY;COUNT=3;INTERVAL=1;BYDAY=MO;BYSETPOS=3') > -1);
+        });
+    });
 });


### PR DESCRIPTION
Added support for repeating bySetPos (integer, must be used with byDay).

Must include byDay when used with bySetPos. Will use the first element of the byDay array (if sent multiple values) when bySetPos is present.

Added test coverage for the changes. Updated readme documentation.