### PR TITLE
Fix Blob constructor invocation

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -312,7 +312,7 @@ class ICalCalendar {
      * @returns {String}
      */
     toURL() {
-        const blob = new Blob(this._generate(), {type: 'text/calendar'});
+        const blob = new Blob([this._generate()], {type: 'text/calendar'});
         return URL.createObjectURL(blob);
     }
 


### PR DESCRIPTION
The Blob constructor takes a list of parts. This was previously causing `TypeError: Value is not a sequence` in e.g. Safari 12.