### PR TITLE
Fix optional param typing issue for calendar.serve, fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,9 @@ Save Calendar to disk asynchronously using [fs.writeFile](http://nodejs.org/api/
 Save Calendar to disk synchronously using [fs.writeFileSync](http://nodejs.org/api/fs.html#fs_fs_writefilesync_filename_data_options). Won't work in browsers.
 
 
-#### serve(**_http.ServerResponse_ response**)
+#### serve(**_http.ServerResponse_ response**, [_String_ filename])
 
-Send Calendar to the User when using HTTP. See Quick Start above. Won't work in browsers.
+Send Calendar to the User when using HTTP. See Quick Start above. Won't work in browsers. Defaults to `'calendar.ics'`.
 
 
 #### toURL()
@@ -299,7 +299,7 @@ This and the 'floating' flag (see below) are mutually exclusive, and setting a t
 
 #### timestamp([_moment_|_Date_ stamp]) or stamp([_moment_|_Date_ stamp])
 
-Appointment date of creation as Date object. Default to `new Date()`.
+Appointment date of creation as Date object. Defaults to `new Date()`.
 
 
 #### allDay([_Boolean_ allDay])

--- a/index.d.ts
+++ b/index.d.ts
@@ -151,7 +151,7 @@ declare module 'ical-generator' {
       events(events: EventData[]): ICalCalendar;
       save(path: string, cb: Function): ICalCalendar;
       saveSync(path: string): number;
-      serve(respone: http.ServerResponse, filename: string): ICalCalendar;
+      serve(response: http.ServerResponse, filename?: string): ICalCalendar;
       toString(): string;
       toJSON(): any;
       length(): number;

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -288,7 +288,7 @@ class ICalCalendar {
      * Save ical file with `fs.saveSync`
      *
      * @param {http.ServerResponse} response Response
-     * @param {String} [filename] Filename
+     * @param {String} [filename = 'calendar.ics'] Filename
      * @returns {Number} Number of Bytes written
      */
     serve(response, filename) {


### PR DESCRIPTION
Fixes #121 