### PR TITLE
Use splat imports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,8 @@
 
 declare module 'ical-generator' {
   /** Imports must be inside the module declaration */
-  import moment from 'moment';
-  import http from 'http';
+  import * as moment from 'moment';
+  import * as http from 'http';
 
   /**
    * Tool for generating iCal calendar data


### PR DESCRIPTION
This should prevent TypeScript errors for those who don't have either `esModuleInterop` or `allowSyntheticDefaultImports` on as discussed in #134

Thanks for the heads-up @g-ongenae