### PR TITLE
ICalTools.formatDate should not modify UTC

### DIFF
--- a/src/_tools.js
+++ b/src/_tools.js
@@ -9,7 +9,8 @@ const moment = require('moment-timezone');
  */
 class ICalTools {
     static formatDate(timezone, d, dateonly, floating) {
-        const m = timezone ? moment(d).tz(timezone) : moment(d).utc();
+        let m = timezone ? moment(d).tz(timezone) : moment(d).utc();
+        if(!dateonly && !floating) m = moment(d).utc();
         let s = m.format('YYYYMMDD');
 
         if(!dateonly) {

--- a/test/test_tools.js
+++ b/test/test_tools.js
@@ -37,7 +37,7 @@ describe('ICalTools', function () {
         it('timezone=1 dateonly=0 floating=0', function () {
             assert.strictEqual(
                 ICalTools.formatDate('Europe/Berlin', '2018-07-05T18:24:00.052Z', false, false),
-                '20180705T202400Z'
+                '20180705T182400Z'
             );
         });
 


### PR DESCRIPTION
Rebased from #113 and fixes #99