### PR TITLE
add support for recurrenceid

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,11 @@ event.repeating({
 ```
 
 
+#### recurrenceid([_moment_|_Date_ stamp])
+
+Recurrence date as Date object.
+
+
 #### summary([_String_ summary])
 
 Appointment summary, defaults to empty string.

--- a/examples/example-recurrence.js
+++ b/examples/example-recurrence.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const ical = require('../src/index');
+const moment = require('moment');
+const cal = ical({domain: 'localhost'});
+
+// overwrite domain
+cal.domain('example.com');
+
+cal.createEvent({
+    start: moment().add(1, 'hour'),
+    end: moment().add(2, 'hours'),
+    summary: 'Example Recurrence-Id',
+    recurrenceid: moment().add(4, 'hour')
+});
+
+console.log(cal.toString());

--- a/index.d.ts
+++ b/index.d.ts
@@ -73,6 +73,7 @@ declare module 'ical-generator' {
       alarms?: AlarmData[];
       status?: string;
       timezone?: string;
+      recurrenceid?: moment.Moment | Date;
     }
 
     interface RepeatingData {

--- a/src/event.js
+++ b/src/event.js
@@ -1028,7 +1028,7 @@ class ICalEvent {
 
         // RECURRENCE
         if (this._data.recurrenceid) {
-            g += ICalTools.formatDateTZ(this._calendar.recurrenceid(), 'RECURRENCE-ID', this._data.recurrenceid, this._data) + '\r\n';
+            g += ICalTools.formatDateTZ(this._calendar.timezone(), 'RECURRENCE-ID', this._data.recurrenceid, this._data) + '\r\n';
         }
 
         // SUMMARY

--- a/src/event.js
+++ b/src/event.js
@@ -62,7 +62,8 @@ class ICalEvent {
             'busystatus',
             'url',
             'created',
-            'lastModified'
+            'lastModified',
+            'recurrenceid'
         ];
         this._vars = {
             allowedRepeatingFreq: ['SECONDLY', 'MINUTELY', 'HOURLY', 'DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY'],
@@ -212,6 +213,36 @@ class ICalEvent {
             this._data.end = t;
         }
 
+        return this;
+    }
+
+    /**
+     * Set/Get the event's recurrence id
+     *
+     * @since 0.2.0
+     * @param {Date|moment|String|null} [recurrenceid] Recurrence date as moment.js object
+     * @returns {ICalEvent|Date}
+     */
+    recurrenceid(recurrenceid) {
+        if (recurrenceid === undefined) {
+            return this._data.recurrenceid;
+        }
+
+        if (typeof recurrenceid === 'string') {
+            recurrenceid = moment(recurrenceid);
+        }
+        else if (recurrenceid instanceof Date) {
+            recurrenceid = moment(recurrenceid);
+        }
+        else if (!(recurrenceid instanceof moment)) {
+            throw new Error('`recurrenceid` must be a Date or a moment object!');
+        }
+
+        if (!recurrenceid.isValid()) {
+            throw new Error('`recurrenceid` has to be a valid date!');
+        }
+
+        this._data.recurrenceid = recurrenceid;
         return this;
     }
 
@@ -993,6 +1024,11 @@ class ICalEvent {
                     }).join(',') + '\r\n';
                 }
             }
+        }
+
+        // RECURRENCE
+        if (this._data.recurrenceid) {
+            g += ICalTools.formatDateTZ(this._calendar.recurrenceid(), 'RECURRENCE-ID', this._data.recurrenceid, this._data) + '\r\n';
         }
 
         // SUMMARY

--- a/test/test_event.js
+++ b/test/test_event.js
@@ -199,6 +199,48 @@ describe('ical-generator Event', function () {
         });
     });
 
+    describe('recurrenceid()', function () {
+        it('getter should return value', function () {
+            const now = moment();
+            const event = new ICalEvent(null, new ICalCalendar());
+            event._data.recurrenceid = now;
+            assert.ok(event.recurrenceid().isSame(now));
+        });
+
+        it('setter should parse string if required', function () {
+            const event = new ICalEvent(null, new ICalCalendar());
+            const date = moment().add(1, 'week');
+            assert.deepStrictEqual(event, event.recurrenceid(date.toJSON()));
+            assert.ok(event._data.recurrenceid.isSame(date));
+        });
+
+        it('setter should handle Dates if required', function () {
+            const event = new ICalEvent(null, new ICalCalendar());
+            const date = moment().add(1, 'week');
+            assert.deepStrictEqual(event, event.recurrenceid(date.toDate()));
+            assert.ok(event._data.recurrenceid.isSame(date));
+        });
+
+        it('setter should throw error when time is not a Date', function () {
+            const event = new ICalEvent(null, new ICalCalendar());
+            assert.throws(function () {
+                event.recurrenceid(3);
+            }, /`recurrenceid`/, 'Number');
+            assert.throws(function () {
+                event.recurrenceid(NaN);
+            }, /`recurrenceid`/, 'NaN');
+            assert.throws(function () {
+                event.recurrenceid(new Date('hallo'));
+            }, /`recurrenceid`/, 'Invalid Date');
+        });
+
+        it('setter should return this', function () {
+            const event = new ICalEvent(null, new ICalCalendar());
+            assert.deepStrictEqual(event, event.recurrenceid(moment()));
+            assert.deepStrictEqual(event, event.recurrenceid(new Date()));
+        });
+    });
+
     describe('timezone()', function () {
         it('getter should return value', function () {
             const e = new ICalEvent(null, new ICalCalendar()).timezone('Europe/Berlin');


### PR DESCRIPTION
This PR adds support for setting the `RECURRENCE-ID` iCal property via `recurrenceid`. This is [defined in the RFC](https://tools.ietf.org/html/rfc5545#section-3.8.4.4) as a datetime string.

- Added example
- Added test harness
- Added to TS model
- Added README

This addresses https://github.com/sebbo2002/ical-generator/issues/145. 

Let me know if you have any questions/comments/concerns. Thanks for all your help.