### PR TITLE
EXDATE: Adding support for TZID

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,8 @@ event.repeating({
     byMonth: [1, 2], // repeat only in january und february,
     byMonthDay: [1, 15], // repeat only on the 1st and 15th
     bySetPos: 3, // repeat every 3rd sunday (will take the first element of the byDay array)
-    exclude: [new Date('Dec 25 2013 00:00:00 UTC')] // exclude these dates
+    exclude: [new Date('Dec 25 2013 00:00:00 UTC')], // exclude these dates
+    excludeTimezone: 'Europe/Berlin' // timezone of exclude
 });
 ```
 

--- a/src/event.js
+++ b/src/event.js
@@ -502,6 +502,14 @@ class ICalEvent {
             });
         }
 
+        if (repeating.excludeTimezone) {
+            if (!c._data.repeating.exclude) {
+                throw '`repeating.excludeTimezone` must be used along with `repeating.exclude`!';
+            }
+
+            c._data.repeating.excludeTimezone = repeating.excludeTimezone;
+        }
+
         return c;
     }
 
@@ -1023,9 +1031,19 @@ class ICalEvent {
                     }).join(',') + '\r\n';
                 }
                 else {
-                    g += 'EXDATE:' + this._data.repeating.exclude.map(excludedDate => {
-                        return ICalTools.formatDate(this._calendar.timezone(), excludedDate);
-                    }).join(',') + '\r\n';
+                    g += 'EXDATE';
+                    if (this._data.repeating.excludeTimezone) {
+                        g += ';TZID=' + this._data.repeating.excludeTimezone + ':' + this._data.repeating.exclude.map(excludedDate => {
+                            // This isn't a 'floating' event because it has a timezone;
+                            // but we use it to omit the 'Z' UTC specifier in formatDate()
+                            return ICalTools.formatDate(this._data.repeating.excludeTimezone, excludedDate, false, true);
+                        }).join(',') + '\r\n';
+                    }
+                    else {
+                        g += ':' + this._data.repeating.exclude.map(excludedDate => {
+                            return ICalTools.formatDate(this._calendar.timezone(), excludedDate);
+                        }).join(',') + '\r\n';
+                    }
                 }
             }
         }

--- a/test/test_event.js
+++ b/test/test_event.js
@@ -469,7 +469,7 @@ describe('ical-generator Event', function () {
 
     describe('repeating()', function () {
         it('getter should return value', function () {
-            const options = {freq: 'MONTHLY', count: 5, interval: 2, exclude: moment(), until: moment()};
+            const options = {freq: 'MONTHLY', count: 5, interval: 2, exclude: moment(), excludeTimezone: 'Europe/Berlin', until: moment()};
             const e = new ICalEvent(null, new ICalCalendar());
             assert.deepStrictEqual(e.repeating(), null);
 
@@ -861,6 +861,37 @@ describe('ical-generator Event', function () {
             assert.ok(e._data.repeating.exclude[0].isSame(date), 'String');
             assert.ok(e._data.repeating.exclude[1].isSame(date), 'Date');
             assert.ok(e._data.repeating.exclude[2].isSame(date), 'Moment');
+        });
+
+        it('should throw error when repeating.excludeTimezone is used when no repeating.exclude', function () {
+            assert.throws(function () {
+                new ICalEvent({
+                    start: moment(),
+                    end: moment(),
+                    summary: 'test',
+                    repeating: {
+                        freq: 'DAILY',
+                        interval: 2,
+                        byDay: ['SU'],
+                        excludeTimezone: 'Europe/Berlin'
+                    }
+                }, new ICalCalendar());
+            }, /must be used along with `repeating.exclude`!/);
+        });
+
+        it('setter should update repeating.excludeTimezone', function () {
+            const e = new ICalEvent(null, new ICalCalendar());
+            const date = moment().add(1, 'week');
+
+            e.repeating({
+                freq: 'monthly', exclude: [
+                    date.toJSON(),
+                    date.toDate(),
+                    date
+                ], excludeTimezone: 'Europe/Berlin'
+            });
+
+            assert.ok(e._data.repeating.excludeTimezone, 'Europe/Berlin');
         });
     });
 


### PR DESCRIPTION
According to [ical's `EXDATE` spec](https://www.kanzaki.com/docs/ical/exdate.html), `EXDATE` can be written with the `TZID` data:

_(This example is taken from the [`RRULE` spec](https://www.kanzaki.com/docs/ical/rrule.html))_
```
Every Friday the 13th, forever:

  DTSTART;TZID=US-Eastern:19970902T090000
  EXDATE;TZID=US-Eastern:19970902T090000
  RRULE:FREQ=MONTHLY;BYDAY=FR;BYMONTHDAY=13

  ==> (1998 9:00 AM EST)February 13;March 13;November 13
      (1999 9:00 AM EDT)August 13
      (2000 9:00 AM EDT)October 13
```

This PR adds the property `excludeTimezone` to the `repeating` property of events. If present, this property will add the `TZID` data to the `EXDATE`.

**Note:** I've tried to add a test checking the ical output, but I didn't understand how. I would be very grateful if someone can help me with that. 