### PR TITLE
Allow iCal extensions to be selectively disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ const cal = ical();
 cal.domain('sebbo.net');
 ```
 
+You can also configure the generator options through the `options` property.
+
+```javascript
+const ical = require('ical-generator');
+
+// omit the `X-WR-CALDESC` extension in the generated output
+const cal = ical({
+    options: { enabledCalndescExtension: false }
+});
+```
+
 
 ### Calendar
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ const ical = require('ical-generator');
 
 // omit the `X-WR-CALDESC` extension in the generated output
 const cal = ical({
-    options: { enabledCalndescExtension: false }
+    options: { enableCaldescExtension: false }
 });
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,17 @@ declare module 'ical-generator' {
       url?: string;
       calscale?: string;
       events?: EventData[];
+      options?: CalendarOptions;
+    }
+
+    /**
+     * Options for iCal generation
+     */
+    interface CalendarOptions {
+      enableCalnameExtension?: boolean;
+      enableCaldescExtension?: boolean;
+      enableTimezoneExtension?: boolean;
+      enablePublishedTtlExtension?: boolean;
     }
 
     /**

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -22,6 +22,13 @@ class ICalCalendar {
             data = JSON.parse(data);
         }
 
+        this._options = Object.assign({
+            enableCalnameExtension: true,
+            enableCaldescExtension: true,
+            enableTimezoneExtension: true,
+            enablePublishedTtlExtension: true,
+        }, data ? data.options || {} : {});
+
         this.clear();
 
         for (let i in data) {
@@ -235,10 +242,10 @@ class ICalCalendar {
             return this._data.ttl;
         }
 
-        if(moment.isDuration(ttl)) {
+        if (moment.isDuration(ttl)) {
             this._data.ttl = ttl;
         }
-        else if(parseInt(ttl, 10) > 0) {
+        else if (parseInt(ttl, 10) > 0) {
             this._data.ttl = moment.duration(parseInt(ttl, 10), 'seconds');
         }
         else {
@@ -335,7 +342,7 @@ class ICalCalendar {
      * @returns {String}
      */
     toURL() {
-        const blob = new Blob([this._generate()], {type: 'text/calendar'});
+        const blob = new Blob([this._generate()], { type: 'text/calendar' });
         return URL.createObjectURL(blob);
     }
 
@@ -423,24 +430,30 @@ class ICalCalendar {
         // NAME
         if (this._data.name) {
             g += 'NAME:' + this._data.name + '\r\n';
-            g += 'X-WR-CALNAME:' + this._data.name + '\r\n';
+            if (this._options.enableCalnameExtension) {
+                g += 'X-WR-CALNAME:' + this._data.name + '\r\n';
+            }
         }
 
         // Description
-        if (this._data.description) {
+        if (this._data.description && this._options.enableCaldescExtension) {
             g += 'X-WR-CALDESC:' + this._data.description + '\r\n';
         }
 
         // Timezone
         if (this._data.timezone) {
             g += 'TIMEZONE-ID:' + this._data.timezone + '\r\n';
-            g += 'X-WR-TIMEZONE:' + this._data.timezone + '\r\n';
+            if (this._options.enableTimezoneExtension) {
+                g += 'X-WR-TIMEZONE:' + this._data.timezone + '\r\n';
+            }
         }
 
         // TTL
         if (this._data.ttl) {
             g += 'REFRESH-INTERVAL;VALUE=DURATION:' + this._data.ttl.toISOString() + '\r\n';
-            g += 'X-PUBLISHED-TTL:' + this._data.ttl.toISOString() + '\r\n';
+            if (this._options.enablePublishedTtlExtension) {
+                g += 'X-PUBLISHED-TTL:' + this._data.ttl.toISOString() + '\r\n';
+            }
         }
 
         // Events

--- a/test/test_calendar.js
+++ b/test/test_calendar.js
@@ -11,6 +11,12 @@ describe('ical-generator Calendar', function () {
             assert.ok(cal._attributes.length > 0);
         });
 
+        it('shoud extend default _options', function () {
+            const cal = new ICalCalendar({ options: { enableCalnameExtension: false } });
+            assert.equal(cal._options.enableCalnameExtension, false);
+            assert.equal(cal._options.enableCaldescExtension, true);
+        });
+
         it('shoud load json export', function () {
             const cal = new ICalCalendar('{"name":"hello-world"}');
             assert.strictEqual(cal._data.name, 'hello-world');
@@ -125,7 +131,7 @@ describe('ical-generator Calendar', function () {
         });
 
         it('should change something', function () {
-            const c = new ICalCalendar({method: 'publish'});
+            const c = new ICalCalendar({ method: 'publish' });
             assert.strictEqual(c._data.method, 'PUBLISH');
 
             c.method('add');
@@ -295,7 +301,7 @@ describe('ical-generator Calendar', function () {
 
         it('should pass data to instance', function () {
             const cal = new ICalCalendar();
-            const event = cal.createEvent({summary: 'Patch-Day'});
+            const event = cal.createEvent({ summary: 'Patch-Day' });
 
             assert.strictEqual(event.summary(), 'Patch-Day');
         });
@@ -324,7 +330,7 @@ describe('ical-generator Calendar', function () {
             const cal = new ICalCalendar();
             assert.strictEqual(cal.length(), 0);
 
-            const cal2 = cal.events([{summary: 'Event A'}, {summary: 'Event B'}]);
+            const cal2 = cal.events([{ summary: 'Event A' }, { summary: 'Event B' }]);
             assert.strictEqual(cal.length(), 2);
             assert.deepStrictEqual(cal2, cal);
         });
@@ -418,7 +424,7 @@ describe('ical-generator Calendar', function () {
                 }).listen(port, function () {
                     function request(cb) {
                         // make request
-                        const req = http.request({port}, function (res) {
+                        const req = http.request({ port }, function (res) {
                             let file = '';
 
                             assert.strictEqual(
@@ -517,10 +523,23 @@ describe('ical-generator Calendar', function () {
             assert.ok(cal.toString().indexOf('X-WR-CALNAME:TEST') > -1);
         });
 
+        it('should respect the enableCalnameExtension option', function () {
+            const cal = new ICalCalendar({ options: { enableCalnameExtension: false } });
+            cal._data.name = 'TEST';
+            assert.ok(cal.toString().indexOf('NAME:TEST') > -1);
+            assert.equal(cal.toString().indexOf('X-WR-CALNAME:TEST'), -1);
+        });
+
         it('should include the description', function () {
             const cal = new ICalCalendar();
             cal._data.description = 'TEST';
             assert.ok(cal.toString().indexOf('X-WR-CALDESC:TEST') > -1);
+        });
+
+        it('should respect the enableCalndescExtension option', function () {
+            const cal = new ICalCalendar({ options: { enableCaldescExtension: false } });
+            cal._data.description = 'TEST';
+            assert.equal(cal.toString().indexOf('X-WR-CALDESC:TEST'), -1);
         });
 
         it('should include the timezone', function () {
@@ -530,11 +549,25 @@ describe('ical-generator Calendar', function () {
             assert.ok(cal.toString().indexOf('X-WR-TIMEZONE:TEST') > -1);
         });
 
-        it('should include the timezone', function () {
+        it('should respect the enableTimezoneExtension option', function () {
+            const cal = new ICalCalendar({ options: { enableTimezoneExtension: false } });
+            cal._data.timezone = 'TEST';
+            assert.ok(cal.toString().indexOf('TIMEZONE-ID:TEST') > -1);
+            assert.equal(cal.toString().indexOf('X-WR-TIMEZONE:TEST'), -1);
+        });
+
+        it('should include the TTL', function () {
             const cal = new ICalCalendar();
             cal._data.ttl = moment.duration(3, 'days');
             assert.ok(cal.toString().indexOf('REFRESH-INTERVAL;VALUE=DURATION:P3D') > -1);
             assert.ok(cal.toString().indexOf('X-PUBLISHED-TTL:P3D') > -1);
+        });
+
+        it('should respect the enablePublishedTtlExtension option', function () {
+            const cal = new ICalCalendar({ options: { enablePublishedTtlExtension: false } });
+            cal._data.ttl = moment.duration(3, 'days');
+            assert.ok(cal.toString().indexOf('REFRESH-INTERVAL;VALUE=DURATION:P3D') > -1);
+            assert.equal(cal.toString().indexOf('X-PUBLISHED-TTL:P3D'), -1);
         });
     });
 });


### PR DESCRIPTION
This adds a new constructor property which allows the user to configure which iCal extensions are enabled. All currently-used extension fields are enabled by default. This allows for selective disabling of extensions, which may be necessary depending on the use-case and which calendar providers are being targeted.