### PR TITLE
Upgrade to Babel 7

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,15 @@
 {
-  "presets": ["es2015"]
+  "presets": [
+    [
+      "@babel/preset-env", {
+        "targets": {
+          "node": "6.17.1",
+          "browsers": [
+            "> 0.25%",
+            "not dead"
+          ]
+        }
+      }
+    ]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -19,17 +19,17 @@
     "@babel/preset-env": "^7.0.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-add-module-exports": "^1.0.2",
-    "eslint": "^6.3.0",
+    "eslint": "^6.5.1",
     "jquery": "^3.4.1",
     "jshint": "^2.10.2",
-    "mocha": "^6.2.0",
+    "mocha": "^6.2.1",
     "mochawesome": "^4.1.0",
     "moment": "^2.24.0",
     "npm-check": "^5.9.0",
     "nyc": "^14.1.1",
-    "portfinder": "^1.0.23",
-    "webpack": "^4.39.3",
-    "webpack-cli": "^3.3.7"
+    "portfinder": "^1.0.24",
+    "webpack": "^4.41.0",
+    "webpack-cli": "^3.3.9"
   },
   "peerDependencies": {
     "@types/node": ">= 8.0.0"

--- a/package.json
+++ b/package.json
@@ -14,12 +14,11 @@
     "moment-timezone": "^0.5.26"
   },
   "devDependencies": {
-    "babel": "^6.23.0",
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.3",
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-add-module-exports": "^1.0.2",
-    "babel-preset-es2015": "^6.24.1",
     "eslint": "^6.3.0",
     "jquery": "^3.4.1",
     "jshint": "^2.10.2",
@@ -46,7 +45,7 @@
     "coverage": "nyc --reporter=html --reporter=text --report-dir ./test-result/coverage --check-coverage mocha -c ./test/*.js",
     "browser-test": "webpack && mkdir -p ./test-result/browser-test && cp ./test/html/index.html ./test-result/browser-test && cp ./node_modules/mocha/mocha.css ./test-result/browser-test && cp ./node_modules/jquery/dist/jquery.min.js  ./test-result/browser-test && cp ./node_modules/mocha/mocha.js ./test-result/browser-test && cp ./node_modules/moment/moment.js ./test-result/browser-test && open ./test-result/browser-test/index.html",
     "bump": "jq -M \".version=\\\"$CI_COMMIT_TAG\\\"\" package.json|sponge package.json",
-    "build": "babel src --presets babel-preset-es2015 --out-dir dist"
+    "build": "babel src --out-dir dist"
   },
   "preferGlobal": false,
   "main": "./dist/index.js",


### PR DESCRIPTION
This updates to Babel 7, and also updates other minor dependencies. The only thing I needed to add was the browsers option in the ```.babelrc``` file. If you have another preference, let me know