### PR TITLE
Apple Calendar map support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ declare module 'ical-generator' {
       lastModified?: moment.Moment | Date;
       description?: string;
       location?: string;
-      appleLocation: AppleLocationData;
+      appleLocation?: AppleLocationData;
       geo?: GeoData;
       url?: string;
       sequence?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,7 @@ declare module 'ical-generator' {
       lastModified?: moment.Moment | Date;
       description?: string;
       location?: string;
+      appleLocation: AppleLocationData;
       geo?: GeoData;
       url?: string;
       sequence?: number;
@@ -137,6 +138,13 @@ declare module 'ical-generator' {
       lon: number;
     }
 
+    interface AppleLocationData {
+      title: string;
+      address: string;
+      radius: number;
+      geo: GeoData;
+    }
+
     /**
      * The calendar object containing all event data
      */
@@ -203,6 +211,8 @@ declare module 'ical-generator' {
       summary(summary: string): ICalEvent;
       location(): string;
       location(location: string): ICalEvent;
+      appleLocation(): AppleLocationData;
+      appleLocation(location: AppleLocationData): ICalEvent;
       geo(): string | null;
       geo(geo: string | GeoData | null): ICalEvent;
       description(): string;

--- a/src/event.js
+++ b/src/event.js
@@ -26,6 +26,7 @@ class ICalEvent {
             repeating: null,
             summary: '',
             location: null,
+            appleLocation: null,
             geo: null,
             description: null,
             htmlDescription: null,
@@ -53,6 +54,7 @@ class ICalEvent {
             'repeating',
             'summary',
             'location',
+            'appleLocation',
             'geo',
             'description',
             'htmlDescription',
@@ -545,6 +547,27 @@ class ICalEvent {
         }
 
         this._data.location = location ? location.toString() : null;
+        return this;
+    }
+
+    /**
+     * Set/Get the Apple event's location
+     *
+     * @param {object} [location]
+     * @since 0.2.0
+     * @returns {ICalEvent|String}
+     */
+    appleLocation (appleLocation) {
+        if (appleLocation === undefined) {
+            return this._data.appleLocation;
+        }
+
+        if (!appleLocation.title || !appleLocation.address || !appleLocation.radius || !appleLocation.geo || !appleLocation.geo.lat || !appleLocation.geo.lon) {
+            throw new Error('`appleLocation` isn\'t formatted correctly.');
+        }
+
+        this._data.appleLocation = appleLocation;
+        this._data.location = null;
         return this;
     }
 
@@ -1061,6 +1084,12 @@ class ICalEvent {
         // LOCATION
         if (this._data.location) {
             g += 'LOCATION:' + ICalTools.escape(this._data.location) + '\r\n';
+        }
+
+         // APPLE LOCATION
+         if (this._data.appleLocation) {
+            g += 'X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-ADDRESS=' + ICalTools.escape(this._data.appleLocation.address) + ';X-APPLE-RADIUS=' + ICalTools.escape(this._data.appleLocation.radius)  + ';X-TITLE=' + ICalTools.escape(this._data.appleLocation.title) +
+            '\r\n:geo:' + ICalTools.escape(this._data.appleLocation.geo.lat) + ',' + ICalTools.escape(this._data.appleLocation.geo.lon) + '\r\n';
         }
 
         // GEO

--- a/src/event.js
+++ b/src/event.js
@@ -1089,7 +1089,7 @@ class ICalEvent {
          // APPLE LOCATION
          if (this._data.appleLocation) {
             g += 'X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-ADDRESS=' + ICalTools.escape(this._data.appleLocation.address) + ';X-APPLE-RADIUS=' + ICalTools.escape(this._data.appleLocation.radius)  + ';X-TITLE=' + ICalTools.escape(this._data.appleLocation.title) +
-            '\r\n:geo:' + ICalTools.escape(this._data.appleLocation.geo.lat) + ',' + ICalTools.escape(this._data.appleLocation.geo.lon) + '\r\n';
+            ':geo:' + ICalTools.escape(this._data.appleLocation.geo.lat) + ',' + ICalTools.escape(this._data.appleLocation.geo.lon) + '\r\n';
         }
 
         // GEO

--- a/src/event.js
+++ b/src/event.js
@@ -567,7 +567,7 @@ class ICalEvent {
         }
 
         this._data.appleLocation = appleLocation;
-        this._data.location = null;
+        this._data.location = this._data.appleLocation.title + '\n' + this._data.appleLocation.address;
         return this;
     }
 


### PR DESCRIPTION
Close #157 

This PR adds support for Apple's Calendar Map. I added a new property to the event model called `appleLocation`. This is the interface of that new property:

```typescript
    interface AppleLocationData {
      title: string;
      address: string;
      radius: number;
      geo: GeoData;
    }

    interface GeoData {
      lat: number;
      lon: number;
    }
```

I decided to doesn't allow the use of `location` and `appleLocation` in the same event, because, if they don't have the same title and address, the map won't work. So, if you use the `appleLocation` property, it'll create under the hood the location and the `X-APPLE-STRUCTURED-LOCATION`, this way, it will always match.

e.g. This object
```typescript
{
  ...
  appleLocation: {
    title: 'My Title',
    address: 'My Address',
    radius: 40,
    geo: {
      lat: '52.063921',
      lon: '5.128511',
    }
  ...
}
```

Will output this:
```
...
LOCATION:My Title\nMy Address
X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-ADDRESS=My Address;X-APPLE-
 RADIUS=40;X-TITLE=My Title:geo:52.063921,5.128511
...
```

This PR also contain the type definitions for this implementation, although I missed the test and the docs.