### PR TITLE
Add separate toBlob and rewrite toUrl so it uses toBlob

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ Save Calendar to disk synchronously using [fs.writeFileSync](http://nodejs.org/a
 
 Send Calendar to the User when using HTTP. See Quick Start above. Won't work in browsers. Defaults to `'calendar.ics'`.
 
+#### toBlob()
+
+Generates a blob to use to download or to generate a download URL. Only supported in browsers supporting this API.
 
 #### toURL()
 

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -324,6 +324,15 @@ class ICalCalendar {
         return this;
     }
 
+    /**
+     * Returns a Blob which you can use to download or to create an url
+     * so it's only working on modern browsers supporting this API.
+     *
+     * @returns {Blob}
+     */
+    toBlob() {
+        return new Blob([this._generate()], {type: 'text/calendar'});
+    }
 
     /**
      * Returns a URL to download the ical file. Uses the Blob object internally,
@@ -335,7 +344,7 @@ class ICalCalendar {
      * @returns {String}
      */
     toURL() {
-        const blob = new Blob([this._generate()], {type: 'text/calendar'});
+        const blob = toBlob()
         return URL.createObjectURL(blob);
     }
 


### PR DESCRIPTION
We used an older version of ical-generator which did not implemented toUrl(). 
We generated our own blob from the calendar event. 
After updating we saw that the package had implemented toUrl().
We use the blob to save the file by "[eventName].ics".
If we use toUrl() and open the url in a new tab the file gets downloaded as "[randomId].ics" which is fine for most people.
This is why I split the toUrl() into a separate toBlob() function so both could be used without creating overhead. 

Unfortunately like Sebastian Pekarek said this cannot be tested since node has no Blob implementation