### PR TITLE
fix: allow X-attrs to be specified in constructor

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -66,7 +66,8 @@ class ICalEvent {
             'url',
             'created',
             'lastModified',
-            'recurrenceId'
+            'recurrenceId',
+            'x'
         ];
         this._vars = {
             allowedRepeatingFreq: ['SECONDLY', 'MINUTELY', 'HOURLY', 'DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY'],


### PR DESCRIPTION
## What

- whitelist `x` in constructor

## Why

- allow this to be specified via passed in object, for example:

```
ical({
    domain: 'sebbo.net',
    prodId: '//superman-industries.com//ical-generator//EN',
    events: [
        {
            start: moment(),
            end: moment().add(1, 'hour'),
            timestamp: moment(),
            summary: 'My Event',
            organizer: 'Sebastian Pekarek <mail@example.com>',
            x: [
              ['LANGUAGE', 'en-GB']
            ]
        }
    ]
});
```