### PR TITLE
Allow event repetition to be specified using rrule string

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,9 +340,9 @@ Appointment is a "floating" time. From [section 3.3.12 of RFC 554](https://tools
 This and the 'timezone' setting (see above) are mutually exclusive, and setting the floating flag will unset the 'timezone'.  If neither 'timezone' nor 'floating' are set, the date will be output with in UTC format (see [date-time form #2 in section 3.3.5 of RFC 554](https://tools.ietf.org/html/rfc5545#section-3.3.5)).
 
 
-#### repeating([_Object_ repeating])
+#### repeating([_Object_ repeating _|_ _String_ rrule])
 
-Appointment is a repeating event
+Appointment is a repeating event. Specify the repetition parameters as an object. Alternatively, pass in a standard rrule string.
 
 ```javascript
 event.repeating({
@@ -357,6 +357,10 @@ event.repeating({
     exclude: [new Date('Dec 25 2013 00:00:00 UTC')], // exclude these dates
     excludeTimezone: 'Europe/Berlin' // timezone of exclude
 });
+```
+
+```javascript
+event.repeating('RRULE:FREQ=WEEKLY;COUNT=30;INTERVAL=1;WKST=MO');
 ```
 
 

--- a/src/event.js
+++ b/src/event.js
@@ -358,7 +358,7 @@ class ICalEvent {
     /**
      * Set/Get the event's repeating stuff
      *
-     * @param {object} [repeating]
+     * @param {object|String} [repeating]
      * @param {String} [repeating.freq]
      * @param {Number} [repeating.count]
      * @param {Number} [repeating.interval]
@@ -378,6 +378,11 @@ class ICalEvent {
         }
         if (!repeating) {
             c._data.repeating = null;
+            return c;
+        }
+
+        if (typeof repeating === 'string' || repeating instanceof String) {
+            c._data.repeating = {rrule: repeating};
             return c;
         }
 
@@ -1046,34 +1051,39 @@ class ICalEvent {
 
         // REPEATING
         if (this._data.repeating) {
-            g += 'RRULE:FREQ=' + this._data.repeating.freq;
-
-            if (this._data.repeating.count) {
-                g += ';COUNT=' + this._data.repeating.count;
+            if (this._data.repeating.rrule) {
+                g += this._data.repeating.rrule;
             }
+            else {
+                g += 'RRULE:FREQ=' + this._data.repeating.freq;
 
-            if (this._data.repeating.interval) {
-                g += ';INTERVAL=' + this._data.repeating.interval;
-            }
-
-            if (this._data.repeating.until) {
-                g += ';UNTIL=' + ICalTools.formatDate(this._calendar.timezone(), this._data.repeating.until);
-            }
-
-            if (this._data.repeating.byDay) {
-                g += ';BYDAY=' + this._data.repeating.byDay.join(',');
-            }
-
-            if (this._data.repeating.byMonth) {
-                g += ';BYMONTH=' + this._data.repeating.byMonth.join(',');
-            }
-
-            if (this._data.repeating.byMonthDay) {
-                g += ';BYMONTHDAY=' + this._data.repeating.byMonthDay.join(',');
-            }
-
-            if (this._data.repeating.bySetPos) {
-                g += ';BYSETPOS=' + this._data.repeating.bySetPos;
+                if (this._data.repeating.count) {
+                    g += ';COUNT=' + this._data.repeating.count;
+                }
+    
+                if (this._data.repeating.interval) {
+                    g += ';INTERVAL=' + this._data.repeating.interval;
+                }
+    
+                if (this._data.repeating.until) {
+                    g += ';UNTIL=' + ICalTools.formatDate(this._calendar.timezone(), this._data.repeating.until);
+                }
+    
+                if (this._data.repeating.byDay) {
+                    g += ';BYDAY=' + this._data.repeating.byDay.join(',');
+                }
+    
+                if (this._data.repeating.byMonth) {
+                    g += ';BYMONTH=' + this._data.repeating.byMonth.join(',');
+                }
+    
+                if (this._data.repeating.byMonthDay) {
+                    g += ';BYMONTHDAY=' + this._data.repeating.byMonthDay.join(',');
+                }
+    
+                if (this._data.repeating.bySetPos) {
+                    g += ';BYSETPOS=' + this._data.repeating.bySetPos;
+                }
             }
 
             g += '\r\n';


### PR DESCRIPTION
Hello,

Thanks for your work on this awesome library!

In my application, I already calculate and store rrule strings for my events. I needed a way to pass these into ical-generator.

I modified the `event.repeating` function to accept an rrule string as an alternative to the parameter object. Then, if present, this rrule string is emitted directly when `_generate` is called on the event.

I imagine this is a relatively common use case so I hope this pull request is helpful. Thanks again for this fantastic package!