### PR TITLE
Re-add Transparency

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,7 @@ declare module 'ical-generator' {
       status?: string;
       timezone?: string;
       recurrenceId?: moment.Moment | Date;
+      transparency?: string;
     }
 
     interface RepeatingData {
@@ -222,6 +223,8 @@ declare module 'ical-generator' {
       url(): string;
       url(url: string): ICalEvent;
       toJSON(): EventData;
+      transparency(): string;
+      transparency(transparency: string): string;
     }
 
     class ICalAttendee {

--- a/src/event.js
+++ b/src/event.js
@@ -912,7 +912,7 @@ class ICalEvent {
             return this;
         }
 
-        if(this._vars.allowedTranspValues.indexOf(transparency.toUpperCase()) === -1) {
+        if(this._vars.allowedTranspValues.indexOf(transparency.toString().toUpperCase()) === -1) {
             throw new Error('`transparency` must be one of the following: ' + this._vars.allowedTranspValues.join(', ') + '!');
         }
 

--- a/src/event.js
+++ b/src/event.js
@@ -36,6 +36,7 @@ class ICalEvent {
             status: null,
             busystatus: null,
             url: null,
+            transparency: null,
             created: null,
             lastModified: null
         };
@@ -63,6 +64,7 @@ class ICalEvent {
             'status',
             'busystatus',
             'url',
+            'transparency',
             'created',
             'lastModified',
             'recurrenceId'
@@ -70,7 +72,8 @@ class ICalEvent {
         this._vars = {
             allowedRepeatingFreq: ['SECONDLY', 'MINUTELY', 'HOURLY', 'DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY'],
             allowedStatuses: ['CONFIRMED', 'TENTATIVE', 'CANCELLED'],
-            allowedBusyStatuses: ['FREE', 'TENTATIVE', 'BUSY', 'OOF']
+            allowedBusyStatuses: ['FREE', 'TENTATIVE', 'BUSY', 'OOF'],
+            allowedTranspValues: ['TRANSPARENT', 'OPAQUE']
         };
 
         this._calendar = _calendar;
@@ -893,6 +896,30 @@ class ICalEvent {
         return this;
     }
 
+    /**
+     * Set/Get the event's transparency
+     *
+     * @param {String} transparency
+     * @since 1.7.3
+     * @returns {ICalEvent|String}
+     */
+    transparency (transparency) {
+        if(transparency === undefined) {
+            return this._data.transparency;
+        }
+        if(!transparency) {
+            this._data.transparency = null;
+            return this;
+        }
+
+        if(this._vars.allowedTranspValues.indexOf(transparency.toUpperCase()) === -1) {
+            throw new Error('`transparency` must be one of the following: ' + this._vars.allowedTranspValues.join(', ') + '!');
+        }
+
+        this._data.transparency = transparency.toUpperCase();
+        return this;
+    }
+
 
     /**
      * Set/Get the event's creation date
@@ -1057,6 +1084,11 @@ class ICalEvent {
 
         // SUMMARY
         g += 'SUMMARY:' + ICalTools.escape(this._data.summary) + '\r\n';
+
+        // TRANSPARENCY
+        if(this._data.transparency) {
+            g += 'TRANSP:' + ICalTools.escape(this._data.transparency) + '\r\n';
+        }
 
         // LOCATION
         if (this._data.location) {

--- a/test/test_event.js
+++ b/test/test_event.js
@@ -1533,6 +1533,52 @@ describe('ical-generator Event', function () {
         });
     });
 
+    describe('transparency()', function () {
+        it('getter should return value', function () {
+            const event = new ICalEvent(null, new ICalCalendar());
+            assert.strictEqual(event.transparency(), null);
+
+            event._data.transparency = 'OPAQUE';
+            assert.strictEqual(event.transparency(), 'OPAQUE');
+
+            event._data.transparency = null;
+            assert.strictEqual(event.transparency(), null);
+        });
+
+        it('setter should return this', function () {
+            const e = new ICalEvent(null, new ICalCalendar());
+            assert.deepStrictEqual(e, e.transparency(null));
+            assert.deepStrictEqual(e, e.transparency('TRANSPARENT'));
+        });
+
+        it('setter should allow setting null', function () {
+            const e = new ICalEvent(null, new ICalCalendar());
+            e._data.transparency = 'OPAQUE';
+            e.transparency(null);
+            assert.strictEqual(e._data.transparency, null);
+        });
+
+        it('setter should allow setting valid value', function () {
+            const e = new ICalEvent(null, new ICalCalendar());
+            e.transparency('OPAQUE');
+            assert.strictEqual(e._data.transparency, 'OPAQUE');
+        });
+
+        it('should throw error when method not allowed', function () {
+            const e = new ICalEvent(null, new ICalCalendar());
+            assert.throws(function () {
+                e.transparency('COOKING');
+            }, /`transparency`/);
+            assert.throws(function () {
+                e.transparency(Infinity);
+            }, /`transparency`/);
+            assert.throws(function () {
+                e.transparency(-1);
+            }, /`transparency`/);
+        });
+    });
+
+
     describe('_generate()', function () {
         it('shoult throw an error without start', function () {
             const e = new ICalEvent({
@@ -1543,7 +1589,7 @@ describe('ical-generator Event', function () {
             }, /`start`/);
         });
 
-        it('shoult make use of escaping', function () {
+        it('should make use of escaping', function () {
             const e = new ICalEvent({
                 start: new Date(),
                 end: new Date(new Date().getTime() + 3600000),


### PR DESCRIPTION
Looks like transp() was included in v1.0, but the code is somehow not in the current version. I changed the function name to transparency() because I thought transp() didn't make much sense unless you knew what it meant. Let me know if you prefer transp and I'll change it back