### PR TITLE
Add missing string input options to interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,14 +298,14 @@ Use this method to set the event's revision sequence number of the
 calendar component within a sequence of revisions.
 
 
-#### start([_moment_|_Date_ start])
+#### start([_moment_|_Date_|_string_ start])
 
-Appointment date of beginning as Date object. This is required for all events!
+Appointment date of beginning as a Moment or Date object or ISO 8601 string. This is required for all events!
 
 
-#### end([_moment_|_Date_ end])
+#### end([_moment_|_Date_|_string_ end])
 
-Appointment date of end as Date object.
+Appointment date of end as a Moment or Date object or ISO 8601 string.
 
 
 #### timezone([_String_ timezone])
@@ -315,9 +315,9 @@ Use this method to set your event's timezone using the TZID property parameter o
 This and the 'floating' flag (see below) are mutually exclusive, and setting a timezone will unset the 'floating' flag.  If neither 'timezone' nor 'floating' are set, the date will be output with in UTC format (see [date-time form #2 in section 3.3.5 of RFC 554](https://tools.ietf.org/html/rfc5545#section-3.3.5)).
 
 
-#### timestamp([_moment_|_Date_ stamp]) or stamp([_moment_|_Date_ stamp])
+#### timestamp([_moment_|_Date_|_string_ stamp]) or stamp([_moment_|_Date_|_string_ stamp])
 
-Appointment date of creation as Date object. Defaults to `new Date()`.
+Appointment date of creation as as a Moment or Date object or ISO 8601 string. Defaults to `new Date()`.
 
 
 #### allDay([_Boolean_ allDay])
@@ -360,9 +360,9 @@ event.repeating({
 ```
 
 
-#### recurrenceId([_moment_|_Date_ stamp])
+#### recurrenceId([_moment_|_Date_|_string_ stamp])
 
-Recurrence date as Date object.
+Recurrence date as a Moment or Date object or ISO 8601 string.
 
 
 #### summary([_String_ summary])
@@ -601,14 +601,14 @@ Appointment busystatus. May be any of the following: `free`, `tentative`, `busy`
 Add a custom `X-` attribute to the generated calendar file.
 
 
-#### created([_moment_|_Date_ created])
+#### created([_moment_|_Date_|_string_ created])
 
-Date object of the time the appointment was created.
+Moment or Date object or ISO 8601 string of the time the appointment was created.
 
 
-#### lastModified([_moment_|_Date_ lastModified])
+#### lastModified([_moment_|_Date_|_string_ lastModified])
 
-Date object of the time the appointent was modified last.
+Moment or Date object or ISO 8601 string of the time the appointent was modified last.
 
 
 ### Attendee

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,14 +55,14 @@ declare module 'ical-generator' {
      * Information used to create calendar events
      */
     interface EventData {
-      start: moment.Moment | Date;
+      start: moment.Moment | Date | string;
       summary: string;
       id?: string | number;
       uid?: string | number;
-      end?: moment.Moment | Date;
-      stamp?: moment.Moment | Date;
-      created?: moment.Moment | Date;
-      lastModified?: moment.Moment | Date;
+      end?: moment.Moment | Date | string;
+      stamp?: moment.Moment | Date | string;
+      created?: moment.Moment | Date | string;
+      lastModified?: moment.Moment | Date | string;
       description?: string;
       location?: string;
       appleLocation?: AppleLocationData;
@@ -79,7 +79,7 @@ declare module 'ical-generator' {
       status?: string;
       busystatus?: string;
       timezone?: string;
-      recurrenceId?: moment.Moment | Date;
+      recurrenceId?: moment.Moment | Date | string;
       transparency?: string;
     }
 
@@ -92,7 +92,7 @@ declare module 'ical-generator' {
       byMonth?: number[];
       byMonthDay?: number[];
       bySetPos?: number;
-      exclude?: moment.Moment[] | Date[];
+      exclude?: moment.Moment[] | Date[] | string[];
     }
 
     /**


### PR DESCRIPTION
There are currently a number of properties in the interface set as `moment.Moment | Date` where the code also accepts ISO 8601 strings, which can be very useful if using this library in code that doesn't use moment as its date library.