### PR TITLE
Upcase byDay even when used with bySetPos

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ event.repeating({
     interval: 2,
     until: new Date('Jan 01 2014 00:00:00 UTC'),
     byDay: ['su', 'mo'], // repeat only sunday and monday
-    byMonth: [1, 2], // repeat only in january und february,
+    byMonth: [1, 2], // repeat only in january and february,
     byMonthDay: [1, 15], // repeat only on the 1st and 15th
     bySetPos: 3, // repeat every 3rd sunday (will take the first element of the byDay array)
     exclude: [new Date('Dec 25 2013 00:00:00 UTC')], // exclude these dates

--- a/src/event.js
+++ b/src/event.js
@@ -482,7 +482,7 @@ class ICalEvent {
                 throw '`repeating.bySetPos` contains invalid value `' + repeating.bySetPos + '`!';
             }
 
-            c._data.repeating.byDay = [repeating.byDay[0]];
+            c._data.repeating.byDay.splice(1);
             c._data.repeating.bySetPos = repeating.bySetPos;
         }
 

--- a/test/test_event.js
+++ b/test/test_event.js
@@ -801,7 +801,8 @@ describe('ical-generator Event', function () {
         it('setter should update repeating.bySetPos', function () {
             const e = new ICalEvent(null, new ICalCalendar());
 
-            e.repeating({freq: 'monthly', byDay: ['SU'], bySetPos: 2});
+            e.repeating({freq: 'monthly', byDay: ['su'], bySetPos: 2});
+            assert.strictEqual(e._data.repeating.byDay[0], 'SU');
             assert.strictEqual(e._data.repeating.bySetPos, 2);
         });
 


### PR DESCRIPTION
Standalone test case:

```javascript
const icaljs = require('ical.js');
const icalgen = require('ical-generator');

let event = {
  uid: 'unique',
  summary: 'repeat every third sunday',
  start: '2020-02-20T12:00:00Z',
  repeating: {
    freq: 'MONTHLY', // required
    count: 5,
    byDay: 'su', // repeat only sunday
    bySetPos: 3, // repeat every 3rd sunday
  }
}

let ical = icalgen({});
ical.createEvent(event);
console.log(ical.toString());
icaljs.parse(ical.toString());
```