### PR TITLE
make domain optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ cal.domain('sebbo.net');
 
 #### domain([_String_ domain])
 
-Use this method to set your server's hostname. It will be used to generate the feed's UID. Default hostname is your
-server's one (`require('os').hostname()`).
+Use this method to set your server's hostname. If provided, it will be used to generate the feed's UID.
+`require('os').hostname()` can be used to get your server's hostname.
 
 
 #### prodId([_String_|_Object_ prodId])
@@ -289,7 +289,10 @@ Empty the Calender.
 
 #### uid([_String_|_Number_ uid]) or id([_String_|_Number_ id])
 
-Use this method to set the event's ID. If not set, an UID will be generated randomly.  When output, the ID will be suffixed with '@' + your calendar's domain.
+Use this method to set the event's ID. If not set, an UID will be generated randomly.
+If your calendar's domain is provided, the ID will be suffixed with '@' + your calendar's domain.
+If you do not provide a calendar domain, generating an ID using the
+[uuid](https://www.npmjs.com/package/uuid) module is recommended.
 
 
 #### sequence([_Number_ sequence])

--- a/src/event.js
+++ b/src/event.js
@@ -1059,7 +1059,12 @@ class ICalEvent {
 
         // DATE & TIME
         g += 'BEGIN:VEVENT\r\n';
-        g += 'UID:' + this._data.id + '@' + this._calendar.domain() + '\r\n';
+        let domain = this._calendar.domain();
+        if (domain) {
+          g += 'UID:' + this._data.id + '@' + domain + '\r\n';
+        } else {
+          g += 'UID:' + this._data.id + '\r\n';
+        }
 
         // SEQUENCE
         g += 'SEQUENCE:' + this._data.sequence + '\r\n';

--- a/src/event.js
+++ b/src/event.js
@@ -1061,9 +1061,9 @@ class ICalEvent {
         g += 'BEGIN:VEVENT\r\n';
         let domain = this._calendar.domain();
         if (domain) {
-          g += 'UID:' + this._data.id + '@' + domain + '\r\n';
+            g += 'UID:' + this._data.id + '@' + domain + '\r\n';
         } else {
-          g += 'UID:' + this._data.id + '\r\n';
+            g += 'UID:' + this._data.id + '\r\n';
         }
 
         // SEQUENCE

--- a/test/test_event.js
+++ b/test/test_event.js
@@ -1731,7 +1731,7 @@ describe('ical-generator Event', function () {
                 summary: ':)'
             }, cal);
 
-            assert.ok(event._generate().indexOf('UID:42@') > -1, 'without domain');
+            assert.ok(event._generate().indexOf('UID:42\r') > -1, 'without domain');
 
             cal.domain('dojo-enterprises.wtf');
             assert.ok(event._generate().indexOf('UID:42@dojo-enterprises.wtf') > -1, 'with domain');


### PR DESCRIPTION
The current documentation suggests that a calendar's hostname defaults to your server's hostname.  This is not the case.  If no domain is provided, ids are currently generated with an `@unspecified` suffix.  This doesn't seem particularly useful or recommended, as appending `@unspecified` won't help make ids unique.

Appending a domain, while convenient and useful for a number of common uses, interferes other use cases.  In my case, I want to be able to round-trip data from iCalendar format to JSON, so my inputs may already have domains present.  Another use case is people who want to generated feeds with [UUIDs](https://github.com/sebbo2002/ical-generator/issues/203).

This pull request adjusts the documentation to describe how you can construct feeds with either your server's hostname or with UUIDs, and adjusts the code and tests to treat calendar domains as optional.