### PR TITLE
use provided timezone when constructing repeating.exclude

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -504,7 +504,12 @@ class ICalEvent {
             c._data.repeating.exclude = [];
             exclude.forEach(function (excludedDate, i) {
                 if (typeof excludedDate === 'string') {
-                    excludedDate = moment(excludedDate);
+                    let timezone = repeating.excludeTimezone || c._calendar._data.timezone;
+                    if (timezone) {
+                        excludedDate = moment.tz(excludedDate, timezone);
+                    } else {
+                        excludedDate = moment(excludedDate);
+                    }
                 }
                 else if (excludedDate instanceof Date) {
                     excludedDate = moment(excludedDate);

--- a/test/test_issues.js
+++ b/test/test_issues.js
@@ -106,4 +106,47 @@ describe('Issues', function () {
             });
         });
     });
+
+    describe('Issue #210', function () {
+        it('should repeat/exclude with Europe/Berlin', function () {
+            const calendar = ical({
+                domain: 'sebbo.net',
+                prodId: '//superman-industries.com//ical-generator//EN',
+                timezone: 'Europe/Berlin',
+                events: [{
+                    start: '2020-08-13T00:00:00',
+                    summary: 'Example Event',
+                    repeating: {
+                        freq: 'MONTHLY',
+                        count: 12,
+                        exclude: '2020-12-13T00:00:00',
+                        excludeTimezone: 'Europe/Berlin'
+                   }
+                }]
+            });
+
+            const str = calendar.toString();
+            assert.ok(str.indexOf('EXDATE;TZID=Europe/Berlin:20201213T000000') > -1);
+        });
+        it('should repeat/exclude with America/New_York', function () {
+            const calendar = ical({
+                domain: 'sebbo.net',
+                prodId: '//superman-industries.com//ical-generator//EN',
+                timezone: 'America/New_York',
+                events: [{
+                    start: '2020-08-13T00:00:00',
+                    summary: 'Example Event',
+                    repeating: {
+                        freq: 'MONTHLY',
+                        count: 12,
+                        exclude: '2020-12-13T00:00:00',
+                        excludeTimezone: 'America/New_York',
+                   }
+                }]
+            });
+
+            const str = calendar.toString();
+            assert.ok(str.indexOf('EXDATE;TZID=America/New_York:20201213T000000') > -1);
+        });
+    });
 });

--- a/test/test_issues.js
+++ b/test/test_issues.js
@@ -121,7 +121,7 @@ describe('Issues', function () {
                         count: 12,
                         exclude: '2020-12-13T00:00:00',
                         excludeTimezone: 'Europe/Berlin'
-                   }
+                    }
                 }]
             });
 
@@ -141,7 +141,7 @@ describe('Issues', function () {
                         count: 12,
                         exclude: '2020-12-13T00:00:00',
                         excludeTimezone: 'America/New_York',
-                   }
+                    }
                 }]
             });
 


### PR DESCRIPTION
use `excludeTimezone` (falling back to `calendar.timezone`) when constructing repeating `exclude` values