### PR TITLE
Make x key optional in type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,7 @@ declare module 'ical-generator' {
       timezone?: string;
       recurrenceId?: moment.Moment | Date | string;
       transparency?: string;
-      x: { key:string, value:string }[];
+      x?: { key:string, value:string }[];
     }
 
     interface RepeatingData {


### PR DESCRIPTION
Hi there, thanks for this library!

The first example in the readme currently fails with TypeScript (error message below):

<img src=https://user-images.githubusercontent.com/1935696/90251025-5f368000-de3d-11ea-91f0-5de6093342f5.png width=300>

```
Argument of type '{ start: moment.Moment; end: moment.Moment; summary: string; description: string; location: string; url: string; }' is not assignable to parameter of type 'EventData'.
  Property 'x' is missing in type '{ start: moment.Moment; end: moment.Moment; summary: string; description: string; location: string; url: string; }' but required in type 'EventData'.
```

It seems like the `x` key should be optional in the `EventData` interface.