### PR TITLE
require('ical-generator') without '.default'

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,6 @@ npm run browser-test
 
 ## 🙋 FAQ
 
-### I updated to `ical-generator@2.x.x` and now get `TypeError: ical is not a function` errors
-
-If you still want to use `require()` to import in version 2 onwards, please use `require('ical-generator').default`.
-The reason for this change is that from version 2 on, other objects such as types and interfaces required for typescript
-are exported as well ([#247](https://github.com/sebbo2002/ical-generator/issues/247)).
-
 ### What's `Error: Can't resolve 'fs'`?
 `ical-generator` uses the node.js `fs` module to save your calendar on the filesystem. In browser environments, you usually don't need this, so if you pass `null` for fs in your bundler. In webpack this looks like this:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,9 +40,11 @@ import ICalCalendar, {ICalCalendarData} from './calendar';
  *
  * @param data Calendar data
  */
-export default function (data?: ICalCalendarData): ICalCalendar {
+function ical(data?: ICalCalendarData): ICalCalendar {
     return new ICalCalendar(data);
 }
+
+export default ical;
 
 export {
     default as ICalAlarm,
@@ -102,3 +104,7 @@ export {
     escape,
     foldLines
 } from './tools';
+
+if (typeof module !== 'undefined') {
+  module.exports = Object.assign(ical, module.exports);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,5 +106,5 @@ export {
 } from './tools';
 
 if (typeof module !== 'undefined') {
-  module.exports = Object.assign(ical, module.exports);
+    module.exports = Object.assign(ical, module.exports);
 }


### PR DESCRIPTION
overwriting module.exports with Object.assign makes `const ical = require('ical-generator')` fully functional in js.
No need for '.default' anymore.

It changes nothing for typescript. It's only for Javascript, so the following isn't true anymore:

> I updated to ical-generator@2.x.x and now get TypeError: ical is not a function errors
> If you still want to use require() to import in version 2 onwards, please use require('ical-generator').default. The reason for this change is that from version 2 on, other objects such as types and interfaces required for typescript are exported as well (#247).

Destructured requires work the same in js and ts.

### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [x] My change requires a change to the documentation
    - [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [ ] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
