### PR TITLE
Support `SOURCE` icalendar parameter (RFC 7986)

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -349,13 +349,14 @@ export default class ICalCalendar {
 
     
     /**
-     * Get your feed's refresh URL
+     * Get current value of the `SOURCE` attribute. 
      * @since 0.x.x
      */
     source(): string | null;
 
     /**
-     * Set your feed's refresh URL
+     * Use this method to set your feed's `SOURCE` attribute.
+     * This tells the client where to refresh your feed.
      *
      * ```javascript
      * calendar.source('http://example.com/my/original_source.ical');
@@ -782,7 +783,7 @@ export default class ICalCalendar {
         
         // SOURCE
         if (this.data.source) {
-            g += 'SOURCE:' + this.data.source + '\r\n';
+            g += 'SOURCE;VALUE=URI:' + this.data.source + '\r\n';
         }
 
         // CALSCALE

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -22,6 +22,7 @@ export interface ICalCalendarData {
     name?: string | null;
     description?: string | null;
     timezone?: ICalTimezone | string | null;
+    source?: string | null;
     url?: string | null;
     scale?: string | null;
     ttl?: number | Duration | null;
@@ -35,6 +36,7 @@ interface ICalCalendarInternalData {
     name: string | null;
     description: string | null;
     timezone: ICalTimezone | null;
+    source: string | null;
     url: string | null;
     scale: string | null;
     ttl: number | null;
@@ -120,6 +122,7 @@ export default class ICalCalendar {
             name: null,
             description: null,
             timezone: null,
+            source: null,
             url: null,
             scale: null,
             ttl: null,
@@ -132,6 +135,7 @@ export default class ICalCalendar {
         data.name !== undefined && this.name(data.name);
         data.description !== undefined && this.description(data.description);
         data.timezone !== undefined && this.timezone(data.timezone);
+        data.source !== undefined && this.source(data.source);
         data.url !== undefined && this.url(data.url);
         data.scale !== undefined && this.scale(data.scale);
         data.ttl !== undefined && this.ttl(data.ttl);
@@ -340,6 +344,32 @@ export default class ICalCalendar {
             this.data.timezone = timezone;
         }
 
+        return this;
+    }
+
+    
+    /**
+     * Get your feed's refresh URL
+     * @since 0.x.x
+     */
+    source(): string | null;
+
+    /**
+     * Set your feed's refresh URL
+     *
+     * ```javascript
+     * calendar.source('http://example.com/my/original_source.ical');
+     * ```
+     *
+     * @since 0.x.x
+     */
+    source(source: string | null): this;
+    source(source?: string | null): this | string | null {
+        if (url === undefined) {
+            return this.data.source;
+        }
+
+        this.data.source = source || null;
         return this;
     }
 
@@ -748,6 +778,11 @@ export default class ICalCalendar {
         // URL
         if (this.data.url) {
             g += 'URL:' + this.data.url + '\r\n';
+        }
+        
+        // SOURCE
+        if (this.data.source) {
+            g += 'SOURCE:' + this.data.source + '\r\n';
         }
 
         // CALSCALE

--- a/test/calendar.ts
+++ b/test/calendar.ts
@@ -20,6 +20,7 @@ describe('ical-generator Calendar', function () {
                 description: 'Hi, I am the description.',
                 timezone: null,
                 url: 'https://github.com/sebbo2002/ical-generator',
+                source: 'http://example.com/my/original_source.ical',
                 scale: null,
                 ttl: null,
                 events: [],
@@ -226,6 +227,32 @@ describe('ical-generator Calendar', function () {
         it('should change something', function () {
             const cal = new ICalCalendar().ttl(86400);
             assert.strictEqual(cal.ttl(), 86400);
+        });
+    });
+    
+    describe('source()', function () {
+        it('setter should return this', function () {
+            const cal = new ICalCalendar();
+            assert.deepStrictEqual(cal, cal.source('http://example.com/my/original_source.ical'));
+        });
+
+        it('getter should return value', function () {
+            const cal = new ICalCalendar();
+            assert.strictEqual(cal.source(), null);
+            cal.source('http://example.com/my/original_source.ical');
+            assert.strictEqual(cal.source(), 'http://example.com/my/original_source.ical');
+            cal.url(null);
+            assert.strictEqual(cal.url(), null);
+        });
+
+        it('should change something', function () {
+            const cal = new ICalCalendar().source('http://example.com/my/original_source.ical');
+            cal.createEvent({
+                start: new Date(),
+                end: new Date(new Date().getTime() + 3600000),
+                summary: 'Example Event'
+            });
+            assert.ok(cal.url(), 'http://example.com/my/original_source.ical');
         });
     });
 


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - feature
- **What is the current behavior?** (You can also link to an open issue here)
    - https://github.com/sebbo2002/ical-generator/issues/260
- **What is the new behavior (if this is a feature change)?**
    - support `SOURCE` param, which tells clients where to refresh the feed for the calendar.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - n/a
- **Other information**:
    - See corresponding issue: https://github.com/sebbo2002/ical-generator/issues/260


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [x] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
