### PR TITLE
Remove last traces of the `domain` option

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -102,16 +102,16 @@ export default class ICalCalendar {
      * // const ical = require('ical-generator');
      *
      *
-     * const cal = ical({domain: 'sebbo.net'});
+     * const cal = ical({name: 'my first iCal'});
      *
      * // is the same as
      *
-     * const cal = ical().domain('sebbo.net');
+     * const cal = ical().name('my first iCal');
      *
      * // is the same as
      *
      * const cal = ical();
-     * cal.domain('sebbo.net');
+     * cal.name('sebbo.net');
      * ```
      *
      * @param data Calendar data


### PR DESCRIPTION
The current jsdocs for the ical method are currently misleading. 

Sorry for not following the PR template, I just didn't think this warranted filling out all the fields.

Thanks for your work on this module!