### PR TITLE
Change createAlarm type property to enum in documentation

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -932,11 +932,11 @@ export default class ICalEvent {
      * ```javascript
      * const cal = ical();
      * const event = cal.createEvent();
-     * const alarm = event.createAlarm({type: 'display', trigger: 300});
+     * const alarm = event.createAlarm({type: ICalAlarmType.display, trigger: 300});
      *
      * // add another alarm
      * event.createAlarm({
-     *     type: 'audio',
+     *     type: ICalAlarmType.audio,
      *     trigger: 300, // 5min before event
      * });
      * ```
@@ -963,8 +963,8 @@ export default class ICalEvent {
      * const event = ical().createEvent();
      *
      * cal.alarms([
-     *     {type: 'display', trigger: 600},
-     *     {type: 'audio', trigger: 300}
+     *     {type: ICalAlarmType.display, trigger: 600},
+     *     {type: ICalAlarmType.audio, trigger: 300}
      * ]);
      *
      * cal.alarms(); // --> [ICalAlarm, ICalAlarm]


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - It's a documentation update as using a string for the "type" property doesn't seem to work
- **What is the current behavior?** (You can also link to an open issue here)
    - The documentation says that a string of 'display' or 'audio' can be assigned to the type property
- **What is the new behavior (if this is a feature change)?**
    - The documentation now says that an enum of ICalAlarmType can be assigned to the type property
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - nope :D
- **Other information**:
    - If this was not the intended behaviour, maybe the functionality could be changed to accept the string?
    - Also, thank you so much for making the package, much appreciated :)


### Pull Request Checklist

- [ ] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [ ] All new and existing tests passed
- [ ] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
