### PR TITLE
Changes to acceptable values for bySetPos and byMonthDay to be consistent with iCalendar spec

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -655,7 +655,7 @@ export default class ICalEvent {
 
 
             this.data.repeating.byMonthDay = byMonthDayArray.map(monthDay => {
-                if (typeof monthDay !== 'number' || monthDay < 1 || monthDay > 31) {
+                if (typeof monthDay !== 'number' || monthDay < -31 || monthDay > 31 || monthDay === 0) {
                     throw new Error('`repeating.byMonthDay` contains invalid value `' + monthDay + '`!');
                 }
 
@@ -667,12 +667,13 @@ export default class ICalEvent {
             if (!this.data.repeating.byDay) {
                 throw '`repeating.bySetPos` must be used along with `repeating.byDay`!';
             }
-            if (typeof repeating.bySetPos !== 'number' || repeating.bySetPos < -1 || repeating.bySetPos > 4) {
-                throw '`repeating.bySetPos` contains invalid value `' + repeating.bySetPos + '`!';
-            }
-
-            this.data.repeating.byDay.splice(1);
-            this.data.repeating.bySetPos = repeating.bySetPos;
+            const bySetPosArray = Array.isArray(repeating.bySetPos) ? repeating.bySetPos : [repeating.bySetPos];
+            this.data.repeating.bySetPos = bySetPosArray.map(bySetPos => {
+              if (typeof bySetPos !== 'number' || bySetPos < -366 || bySetPos > 366 || bySetPos === 0) {
+                  throw '`repeating.bySetPos` contains invalid value `' + bySetPos + '`!';
+              }
+              return bySetPos;
+            })
         }
 
         if (repeating.exclude) {
@@ -1506,7 +1507,7 @@ export default class ICalEvent {
             }
 
             if (this.data.repeating.bySetPos) {
-                g += ';BYSETPOS=' + this.data.repeating.bySetPos;
+                g += ';BYSETPOS=' + this.data.repeating.bySetPos.join(',');
             }
 
             if (this.data.repeating.startOfWeek) {

--- a/src/event.ts
+++ b/src/event.ts
@@ -151,7 +151,7 @@ interface ICalEventInternalRepeatingData {
     byDay?: ICalWeekday[];
     byMonth?: number[];
     byMonthDay?: number[];
-    bySetPos?: number;
+    bySetPos?: number[];
     exclude?: ICalDateTimeValue[];
     startOfWeek?: ICalWeekday;
 }
@@ -669,11 +669,11 @@ export default class ICalEvent {
             }
             const bySetPosArray = Array.isArray(repeating.bySetPos) ? repeating.bySetPos : [repeating.bySetPos];
             this.data.repeating.bySetPos = bySetPosArray.map(bySetPos => {
-              if (typeof bySetPos !== 'number' || bySetPos < -366 || bySetPos > 366 || bySetPos === 0) {
-                  throw '`repeating.bySetPos` contains invalid value `' + bySetPos + '`!';
-              }
-              return bySetPos;
-            })
+                if (typeof bySetPos !== 'number' || bySetPos < -366 || bySetPos > 366 || bySetPos === 0) {
+                    throw '`repeating.bySetPos` contains invalid value `' + bySetPos + '`!';
+                }
+                return bySetPos;
+            });
         }
 
         if (repeating.exclude) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export interface ICalRepeatingOptions {
     byDay?: ICalWeekday[] | ICalWeekday;
     byMonth?: number[] | number;
     byMonthDay?: number[] | number;
-    bySetPos?: number;
+    bySetPos?: number[] | number;
     exclude?: ICalDateTimeValue[] | ICalDateTimeValue;
     startOfWeek?: ICalWeekday;
 }

--- a/test/event.ts
+++ b/test/event.ts
@@ -887,7 +887,7 @@ describe('ical-generator Event', function () {
                         freq: ICalEventRepeatingFreq.MONTHLY,
                         interval: 2,
                         byDay: [ICalWeekday.SU],
-                        bySetPos: 367
+                        bySetPos: [367]
                     }
                 }, new ICalCalendar());
             }, /`repeating\.bySetPos` contains invalid value `367`/);
@@ -901,7 +901,7 @@ describe('ical-generator Event', function () {
                         freq: ICalEventRepeatingFreq.MONTHLY,
                         interval: 2,
                         byDay: [ICalWeekday.SU],
-                        bySetPos: -367
+                        bySetPos: [-367]
                     }
                 }, new ICalCalendar());
             }, /`repeating\.bySetPos` contains invalid value `-367`/);
@@ -915,7 +915,7 @@ describe('ical-generator Event', function () {
                         freq: ICalEventRepeatingFreq.MONTHLY,
                         interval: 2,
                         byDay: [ICalWeekday.SU],
-                        bySetPos: 0
+                        bySetPos: [0]
                     }
                 }, new ICalCalendar());
             }, /`repeating\.bySetPos` contains invalid value `0`/);
@@ -930,7 +930,7 @@ describe('ical-generator Event', function () {
                         interval: 2,
                         byDay: [ICalWeekday.SU],
                         // @ts-ignore
-                        bySetPos: 'FOO'
+                        bySetPos: ['FOO']
                     }
                 }, new ICalCalendar());
             }, /`repeating\.bySetPos` contains invalid value `FOO`/);
@@ -957,13 +957,13 @@ describe('ical-generator Event', function () {
             e.repeating({
                 freq: ICalEventRepeatingFreq.MONTHLY,
                 byDay: [ICalWeekday.SU],
-                bySetPos: 2
+                bySetPos: [2]
             });
 
             const result = e.repeating();
             assert.ok(result && !isRRule(result) && typeof result !== 'string');
             assert.strictEqual(result.byDay?.length, 1);
-            assert.strictEqual(result.bySetPos, [2]);
+            assert.strictEqual(result.bySetPos?.length, 1);
         });
 
         it('should throw error when repeating.exclude is not valid', function () {

--- a/test/event.ts
+++ b/test/event.ts
@@ -835,10 +835,36 @@ describe('ical-generator Event', function () {
                     repeating: {
                         freq: ICalEventRepeatingFreq.DAILY,
                         interval: 2,
-                        byMonthDay: [1, 32, 15]
+                        byMonthDay: [1, 32, -15]
                     }
                 }, new ICalCalendar());
             }, /`repeating\.byMonthDay` contains invalid value `32`/);
+
+            assert.throws(function () {
+                new ICalEvent({
+                    start: moment(),
+                    end: moment(),
+                    summary: 'test',
+                    repeating: {
+                        freq: ICalEventRepeatingFreq.DAILY,
+                        interval: 2,
+                        byMonthDay: [-1, -32, 15]
+                    }
+                }, new ICalCalendar());
+            }, /`repeating\.byMonthDay` contains invalid value `-32`/);
+
+            assert.throws(function () {
+                new ICalEvent({
+                    start: moment(),
+                    end: moment(),
+                    summary: 'test',
+                    repeating: {
+                        freq: ICalEventRepeatingFreq.DAILY,
+                        interval: 2,
+                        byMonthDay: [1, 0, 15]
+                    }
+                }, new ICalCalendar());
+            }, /`repeating\.byMonthDay` contains invalid value `0`/);
         });
 
         it('setter should update repeating.byMonthDay', function () {
@@ -861,10 +887,38 @@ describe('ical-generator Event', function () {
                         freq: ICalEventRepeatingFreq.MONTHLY,
                         interval: 2,
                         byDay: [ICalWeekday.SU],
-                        bySetPos: 6
+                        bySetPos: 367
                     }
                 }, new ICalCalendar());
-            }, /`repeating\.bySetPos` contains invalid value `6`/);
+            }, /`repeating\.bySetPos` contains invalid value `367`/);
+
+            assert.throws(function () {
+                new ICalEvent({
+                    start: moment(),
+                    end: moment(),
+                    summary: 'test',
+                    repeating: {
+                        freq: ICalEventRepeatingFreq.MONTHLY,
+                        interval: 2,
+                        byDay: [ICalWeekday.SU],
+                        bySetPos: -367
+                    }
+                }, new ICalCalendar());
+            }, /`repeating\.bySetPos` contains invalid value `-367`/);
+
+            assert.throws(function () {
+                new ICalEvent({
+                    start: moment(),
+                    end: moment(),
+                    summary: 'test',
+                    repeating: {
+                        freq: ICalEventRepeatingFreq.MONTHLY,
+                        interval: 2,
+                        byDay: [ICalWeekday.SU],
+                        bySetPos: 0
+                    }
+                }, new ICalCalendar());
+            }, /`repeating\.bySetPos` contains invalid value `0`/);
 
             assert.throws(function () {
                 new ICalEvent({
@@ -909,7 +963,7 @@ describe('ical-generator Event', function () {
             const result = e.repeating();
             assert.ok(result && !isRRule(result) && typeof result !== 'string');
             assert.strictEqual(result.byDay?.length, 1);
-            assert.strictEqual(result.bySetPos, 2);
+            assert.strictEqual(result.bySetPos, [2]);
         });
 
         it('should throw error when repeating.exclude is not valid', function () {

--- a/test/issues.ts
+++ b/test/issues.ts
@@ -60,7 +60,7 @@ describe('Issues', function () {
             assert.ok(str.indexOf('RRULE:FREQ=MONTHLY;COUNT=3;INTERVAL=1;BYDAY=SU;BYSETPOS=3') > -1);
         });
 
-        it('should work with repeating bySetPos by taking the first elemnt of the byDay array', function () {
+        it('should work with repeating bySetPos by taking all elements of the byDay array', function () {
             const calendar = ical({
                 prodId: '//superman-industries.com//ical-generator//EN',
                 events: [{
@@ -79,7 +79,7 @@ describe('Issues', function () {
             });
 
             const str = calendar.toString();
-            assert.ok(str.indexOf('RRULE:FREQ=MONTHLY;COUNT=3;INTERVAL=1;BYDAY=MO;BYSETPOS=3') > -1);
+            assert.ok(str.indexOf('RRULE:FREQ=MONTHLY;COUNT=3;INTERVAL=1;BYDAY=MO,FR;BYSETPOS=3') > -1);
         });
     });
 


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - This change introduces two fixes to make the repeating rules for bySetPos and byMonthDay consistent with the iCalendar spec.
- **What is the current behavior?** (You can also link to an open issue here)
    - bySetPos currently only allows a single number to be passed in.
    - bySetPos currently only allows values between -1 and 4.
    - byMonthDay currently only allows values between 1 and 31.
    - If multiple days are specified for byDay when also specifying bySetPos, only the first day passed in the array is used and the remaining ones are discarded.
- **What is the new behavior (if this is a feature change)?**
    - bySetPos is now allowed to be passed in as both a number or an array.
    - bySetPos now allows values between -366 to -1 and 1 to 366.
    - byMonthDay now allows values between -31 to -1 and 1 to 31.
    - If multiple days are specified for byDay, they are all used in conjunction with bySetPos and none are discarded.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - If you're relying on additional values of byDay being discarded when being used with bySetPos, that would be a change to existing behavior. Otherwise, this adds functionality rather than removing or changing it.
- **Other information**:
    - The iCalendar spec describes the guidelines for bySetPos and byMonthDay: https://icalendar.org/iCalendar-RFC-5545/3-3-10-recurrence-rule.html
    - There are two tests failing off of the develop branch that are unrelated to these changes.  They are related to support for Luxon and Day.js. I didn't try to fix those as I don't know much about those libraries.


### Pull Request Checklist

- [X] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [X] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [X] All new and existing tests passed
- [ ] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
