### PR TITLE
docs(Event): Typo in docs for ICalEventBusyStatus

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -1086,7 +1086,7 @@ export default class ICalEvent {
      *
      * ```javascript
      * import ical, {ICalEventBusyStatus} from 'ical-generator';
-     * event.busystatus(ICalEventStatus.BUSY);
+     * event.busystatus(ICalEventBusyStatus.BUSY);
      * ```
      *
      * @since 1.0.2


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Hello! I have noticed while navigating across your documentation that the example given for `ICalEventBusyStatus` was using the wrong type (`ICalEventStatus` used instead)
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - No

### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [x] My change requires a change to the documentation
    - [x] I have updated the documentation accordingly
- [ ] ~~I have added tests to cover my changes~~
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [ ] ~~All new and existing tests passed~~
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
