### PR TITLE
refactor: add `node:` prefix to Node.js imports

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -9,8 +9,8 @@ import {
     toDurationString
 } from './tools.js';
 import ICalEvent, {ICalEventData, ICalEventJSONData} from './event.js';
-import {writeFile, writeFileSync, promises as fsPromises} from 'fs';
-import {ServerResponse} from 'http';
+import {writeFile, writeFileSync, promises as fsPromises} from 'node:fs';
+import {ServerResponse} from 'node:http';
 import { ICalMomentDurationStub, ICalTimezone } from './types.js';
 
 


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?** refactor
- **What is the current behavior?** imports node modules
- **What is the new behavior (if this is a feature change)?** no behavior change
- **Does this PR introduce a breaking change?** no. this project has an `engines` field only supporting Node 16+ which all support this syntax
- **Other information**:

### Pull Request Checklist

- [X] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [X] All new and existing tests passed
- [X] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
