### PR TITLE
fix: add `browser` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "author": "Sebastian Pekarek <mail@sebbo.net>",
+  "browser": {
+    "fs": false
+  },
   "bugs": {
     "url": "http://github.com/sebbo2002/ical-generator/issues"
   },


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?** bug fix

- **What is the current behavior?** doesn't work on cloudflare workers

- **What is the new behavior (if this is a feature change)?**  does work on cloudflare workers

- **Does this PR introduce a breaking change?** no

- **Other information**: as described in https://github.com/sebbo2002/ical-generator/issues/511#issuecomment-1722396735


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
