### PR TITLE
docs(README): Add method to calendar in quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ import http from 'node:http';
 
 const calendar = ical({name: 'my first iCal'});
 
-// A method is required for outlook to display the invitation properly
+// A method is required for outlook to display event as an invitation
 calendar.method(ICalCalendarMethod.REQUEST);
 
 const startTime = new Date();

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ import ical from 'ical-generator';
 import http from 'node:http';
 
 const calendar = ical({name: 'my first iCal'});
+
+// A method is required for outlook to display the invitation properly
+calendar.method(ICalCalendarMethod.REQUEST);
+
 const startTime = new Date();
 const endTime = new Date();
 endTime.setHours(startTime.getHours()+1);


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Updates the README to include a method in the calendar object, so outlook displays the invitation properly. Without it there are no accept/decline buttons shown, and the filename is "calendar not supported message.ics". 
- **What is the current behavior?** (You can also link to an open issue here)
    - …
- **What is the new behavior (if this is a feature change)?**
    - …
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - No
- **Other information**:
    -


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [x] My change requires a change to the documentation
    - [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
