### PR TITLE
fix: fixed core bug with type check

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -170,7 +170,7 @@ export function addOrGetCustomAttributes (data: {x: [string, string][]}, keyOrAr
             return [o.key, o.value] as [string, string];
         });
     }
-    else if (typeof keyOrArray === 'object') {
+    else if (typeof keyOrArray === 'object' && keyOrArray !== null) {
         data.x = Object.entries(keyOrArray).map(([key, value]) => {
             if (typeof key !== 'string' || typeof value !== 'string') {
                 throw new Error('Either key or value is not a string!');


### PR DESCRIPTION
If a value if `null` then it will pass `true` for `typeof obj === 'object'`.  This causes an uncaught exception when `Object.entries(null)` is invoked:

```sh
> Object.entries(null)
Uncaught TypeError: Cannot convert undefined or null to object
    at Function.entries (<anonymous>)
```

### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - …
- **What is the current behavior?** (You can also link to an open issue here)
    - …
- **What is the new behavior (if this is a feature change)?**
    - …
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - …
- **Other information**:
    - …


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)

Per our work on https://forwardemail.net