### PR TITLE
Reproduce problem with tests

### DIFF
--- a/test/event.ts
+++ b/test/event.ts
@@ -16,6 +16,7 @@ import ICalAlarm, { ICalAlarmType } from '../src/alarm.js';
 import ICalCategory from '../src/category.js';
 import { isRRule } from '../src/tools.js';
 import rrule from 'rrule';
+import {DateTime} from 'luxon';
 
 describe('ical-generator Event', function () {
     describe('constructor()', function () {
@@ -2051,6 +2052,23 @@ describe('ical-generator Event', function () {
                 }
             }, cal);
             assert.ok(event.toString().includes('WKST'), 'with WKST');
+        });
+
+        it('should render allday events for luxon dates with timezone correct', function () {
+            const cal = new ICalCalendar();
+            const luxonStartDate = DateTime.fromISO('2024-03-17T00:00:00.000+01:00');
+            const luxonEndDate = DateTime.fromISO('2024-03-18T00:00:00.000+01:00');
+            const event = new ICalEvent({
+                allDay: true,
+                start: luxonStartDate,
+                end: luxonEndDate,
+            }, cal);
+
+            const actual = event.toString();
+            assert.match(actual, new RegExp('X-MICROSOFT-CDO-ALLDAYEVENT:TRUE\r\n'), 'with Microsoft CDO alldayevent set');
+            assert.match(actual, new RegExp('X-MICROSOFT-MSNCALENDAR-ALLDAYEVENT:TRUE\r\n'), 'with Microsoft MSNCalendar alldayevent flag set');
+            assert.match(actual, new RegExp(`DTSTART;VALUE=DATE:${luxonStartDate.toFormat('yyyyLLdd')}\r\n`), 'for DTSTART');
+            assert.match(actual, new RegExp(`DTEND;VALUE=DATE:${luxonEndDate.toFormat('yyyyLLdd')}\r\n`), 'for DTEND');
         });
     });
 });

--- a/test/event.ts
+++ b/test/event.ts
@@ -2056,8 +2056,8 @@ describe('ical-generator Event', function () {
 
         it('should render allday events for luxon dates with timezone correct', function () {
             const cal = new ICalCalendar();
-            const luxonStartDate = DateTime.fromISO('2024-03-17T00:00:00.000+01:00');
-            const luxonEndDate = DateTime.fromISO('2024-03-18T00:00:00.000+01:00');
+            const luxonStartDate = DateTime.fromISO('2024-03-17T00:00:00.000+01:00', {setZone: true});
+            const luxonEndDate = DateTime.fromISO('2024-03-18T00:00:00.000+01:00', {setZone: true});
             const event = new ICalEvent({
                 allDay: true,
                 start: luxonStartDate,

--- a/test/tools.ts
+++ b/test/tools.ts
@@ -145,7 +145,7 @@ describe('ICalTools', function () {
             });
             it('should work with dateonly flag, non floating, and date with timezone', function () {
                 assert.strictEqual(
-                    formatDate(null, DateTime.fromISO('2024-03-17T00:00:00.000+01:00'), true),
+                    formatDate(null, DateTime.fromISO('2024-03-17T00:00:00.000+01:00', {setZone: true}), true),
                     '20240317'
                 );
             });

--- a/test/tools.ts
+++ b/test/tools.ts
@@ -8,7 +8,7 @@ import dayjs from 'dayjs';
 import dayJsUTCPlugin from 'dayjs/plugin/utc.js';
 import dayJsTimezonePlugin from 'dayjs/plugin/timezone.js';
 import {
-    checkDate, 
+    checkDate,
     escape,
     foldLines,
     formatDate,
@@ -141,6 +141,12 @@ describe('ICalTools', function () {
                 assert.strictEqual(
                     formatDate(null, DateTime.fromISO('2018-07-05T18:24:00.052'), true, false),
                     '20180705'
+                );
+            });
+            it('should work with dateonly flag, non floating, and date with timezone', function () {
+                assert.strictEqual(
+                    formatDate(null, DateTime.fromISO('2024-03-17T00:00:00.000+01:00'), true),
+                    '20240317'
                 );
             });
         });


### PR DESCRIPTION
### About this Pull Request

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - The goal is to introduce a bugfix. So far it only introduces two new test, which should be passing in my opinion, but aren't with the current code.
- **What is the current behavior?** (You can also link to an open issue here)
    - If a Luxon DateTime, that is timezoned, is passed for an all day event to a calendar that has otherwise no explicit timezone, then that date it is always rendered in UTC timezone. Depending on the original date, this results in a rendered date of +1 or -1 than the expected date.
    - For example, the Luxon DateTime `DateTime.fromISO('2024-03-17T00:00:00.000+01:00')` is rendered as `DTSTART;VALUE=DATE:20240316\r\n`, when `DTSTART;VALUE=DATE:20240317\r\n` is the expected rendering.
- **What is the new behavior (if this is a feature change)?**
    - I was not able to judge whether this is a problem in `event.ts#toString()` or in `tools.js#formatDate()`, so I added only tests for now.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - I don't expect that.
- **Other information**:
    - I'm not sure how to properly address what I describe in the (currently failing) tests.

### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [ ] All new and existing tests passed
- [ ] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
