### PR TITLE
feat: replace uuid dependency with native crypto method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "ical-generator",
       "version": "8.0.2-develop.6",
       "license": "MIT",
-      "dependencies": {
-        "uuid-random": "^1.3.2"
-      },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
@@ -12682,10 +12679,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/uuid-random": {
-      "version": "1.3.2",
-      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ=="
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
@@ -21423,10 +21416,6 @@
       "version": "8.3.2",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
-    },
-    "uuid-random": {
-      "version": "1.3.2",
-      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "bugs": {
     "url": "http://github.com/sebbo2002/ical-generator/issues"
   },
-  "dependencies": {
-    "uuid-random": "^1.3.2"
-  },
   "description": "ical-generator is a small piece of code which generates ical calendar files",
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/src/event.ts
+++ b/src/event.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import uuid from 'uuid-random';
+import { randomUUID } from 'crypto';
 import {
     addOrGetCustomAttributes,
     checkDate,
@@ -178,7 +178,7 @@ export default class ICalEvent {
      */
     constructor(data: ICalEventData, calendar: ICalCalendar) {
         this.data = {
-            id: uuid(),
+            id: randomUUID(),
             sequence: 0,
             start: new Date(),
             end: null,


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?**
    - Replace external `uuid-random` dependency with native `crypto.randomUUID`. No need to use external code for something the platform provides.
- **What is the current behavior?**
    - Usage of external dependency.
- **What is the new behavior?**
    - Usage of native functionality.
- **Does this PR introduce a breaking change?**
    - As `crypto.randomUUID` has been introduced with [Node.js 16.7.0](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID#browser_compatibility) and the `engine` config in this project's `package.json` states `"node": "18 || 20 || >=22.0.0"`, this should not break anything.
- **Other information**:
  - FWIW, runtimes like Deno [support this approach](https://docs.deno.com/examples/uuids/), too. And current versions of [every major browser](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID#browser_compatibility). So portability should not be affected. Rather the opposite.
  - When this feature was [implemented](https://github.com/sebbo2002/ical-generator/pull/215), there was no native solution available yet.


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
