### PR TITLE
fix: Use WebCrypto instead of node crypto module

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -1,6 +1,5 @@
 'use strict';
 
-import { randomUUID } from 'crypto';
 import {
     addOrGetCustomAttributes,
     checkDate,
@@ -178,7 +177,7 @@ export default class ICalEvent {
      */
     constructor(data: ICalEventData, calendar: ICalCalendar) {
         this.data = {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             sequence: 0,
             start: new Date(),
             end: null,


### PR DESCRIPTION
### About this Pull Request

Fixes https://github.com/sebbo2002/ical-generator/issues/632

Removing `uuid-random` in https://github.com/sebbo2002/ical-generator/pull/631 had the unintended side effect of breaking compatibility with non-node platforms (importing from the 'crypto' module is node specific.)

This change swaps out node's randomUUID implementation with webcrypto's `crypto.randomUUID` instead. This is supported on all current node versions, cloudflare workers etc. 

It should also work in Web Workers, unless on an ancient browser version.

### Pull Request Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have added tests to cover my changes
    - (no new tests on account of this being a no-op in node.)
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
