### PR TITLE
Support TZDate from @date-fns/tz

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ See the [examples](https://github.com/sebbo2002/ical-generator/tree/develop/exam
 
 ical-generator supports [native Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date),
 [Day.js](https://day.js.org/en/), [Luxon's](https://moment.github.io/luxon/) [DateTime](https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html)
-and the older [moment.js](https://momentjs.com/) and [moment-timezone](https://momentjs.com/timezone/)
-objects. You can also pass a string which is then passed to javascript's `Date` internally.
+and the older [moment.js](https://momentjs.com/), [moment-timezone](https://momentjs.com/timezone/)
+objects and [TZDate](https://github.com/date-fns/tz). You can also pass a string which is then passed to javascript's `Date` internally.
 
 It is recommended to use UTC time as far as possible. `ical-generator` will output all time information as UTC time as
 long as no time zone is defined. For day.js, a plugin is necessary for this, which is a prerequisite. If a time zone is

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "9.0.0-develop.5",
             "license": "MIT",
             "devDependencies": {
+                "@date-fns/tz": "^1.2.0",
                 "@eslint/js": "^9.25.0",
                 "@istanbuljs/nyc-config-typescript": "^1.0.2",
                 "@qiwi/semantic-release-gh-pages-plugin": "^5.4.3",
@@ -500,6 +501,13 @@
             "engines": {
                 "node": ">=0.1.90"
             }
+        },
+        "node_modules/@date-fns/tz": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
+            "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.0",
@@ -12722,6 +12730,12 @@
             "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
             "dev": true,
             "optional": true
+        },
+        "@date-fns/tz": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
+            "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
+            "dev": true
         },
         "@esbuild/aix-ppc64": {
             "version": "0.25.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     },
     "description": "ical-generator is a small piece of code which generates ical calendar files",
     "devDependencies": {
+        "@date-fns/tz": "^1.2.0",
         "@eslint/js": "^9.25.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@qiwi/semantic-release-gh-pages-plugin": "^5.4.3",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     },
     "runkitExampleFilename": "examples/example-runkit.js",
     "scripts": {
+        "prepare": "npm run build",
         "build": "tsup && cp ./dist/index.d.ts ./dist/index.d.cts",
         "build-all": "./.github/workflows/build.sh",
         "coverage": "c8 mocha",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -9,6 +9,7 @@ import {
     type ICalMomentTimezoneStub,
     type ICalOrganizer,
     type ICalRRuleStub,
+    type ICalTZDateStub,
 } from './types.ts';
 
 export function addOrGetCustomAttributes(
@@ -244,7 +245,9 @@ export function formatDate(
     }
 
     if (typeof d === 'string' || d instanceof Date) {
-        const m = new Date(d);
+        // TZDate is an extension of the native Date object.
+        // @see https://github.com/date-fns/tz for more information.
+        const m = isTZDate(d) ? d.withTimeZone(timezone) : new Date(d);
 
         // (!dateonly && !floating) || !timezone => utc
         let s =
@@ -419,6 +422,18 @@ export function isRRule(value: unknown): value is ICalRRuleStub {
         'between' in value &&
         typeof value.between === 'function' &&
         typeof value.toString === 'function'
+    );
+}
+
+export function isTZDate(value: ICalDateTimeValue): value is ICalTZDateStub {
+    return (
+        value instanceof Date &&
+        'internal' in value &&
+        value.internal instanceof Date &&
+        'withTimeZone' in value &&
+        typeof value.withTimeZone === 'function' &&
+        'tzComponents' in value &&
+        typeof value.tzComponents === 'function'
     );
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,3 +127,9 @@ export interface ICalTimezone {
     generator?: (timezone: string) => null | string;
     name: null | string;
 }
+
+export interface ICalTZDateStub extends Date {
+    timeZone?: string;
+    tzComponents(): string[];
+    withTimeZone(timezone?: null | string): ICalTZDateStub;
+}

--- a/test/tools.ts
+++ b/test/tools.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import { TZDate } from '@date-fns/tz';
 import assert from 'assert';
 import dayjs from 'dayjs';
 import dayJsTimezonePlugin from 'dayjs/plugin/timezone.js';
@@ -97,6 +98,135 @@ describe('ICalTools', function () {
                     formatDate(
                         '/Europe/Berlin',
                         '2018-07-05T18:24:00.052',
+                        false,
+                        false,
+                    ),
+                    '20180705T182400',
+                );
+            });
+        });
+        describe('TZDate', function () {
+            it('timezone=0 dateonly=0 floating=0', function () {
+                assert.strictEqual(
+                    formatDate(
+                        null,
+                        new TZDate('2018-07-05T18:24:00.052Z'),
+                        false,
+                        false,
+                    ),
+                    '20180705T182400Z',
+                );
+            });
+            it('timezone=0 dateonly=0 floating=1', function () {
+                assert.strictEqual(
+                    formatDate(
+                        null,
+                        new TZDate('2018-07-05T18:24:00.052Z'),
+                        false,
+                        true,
+                    ),
+                    '20180705T182400',
+                );
+            });
+            it('timezone=0 dateonly=1 floating=0', function () {
+                assert.strictEqual(
+                    formatDate(
+                        null,
+                        new TZDate('2018-07-05T18:24:00.052Z'),
+                        true,
+                        false,
+                    ),
+                    '20180705',
+                );
+            });
+            it('timezone=0 dateonly=1 floating=1', function () {
+                assert.strictEqual(
+                    formatDate(
+                        null,
+                        new TZDate('2018-07-05T18:24:00.052Z'),
+                        true,
+                        true,
+                    ),
+                    '20180705',
+                );
+            });
+            it('timezone=1 dateonly=0 floating=0', function () {
+                assert.strictEqual(
+                    formatDate(
+                        'Europe/Berlin',
+                        new TZDate('2018-07-05T18:24:00.052Z'),
+                        false,
+                        false,
+                    ),
+                    '20180705T202400',
+                );
+            });
+            it('timezone=1 dateonly=0 floating=1', function () {
+                assert.strictEqual(
+                    formatDate(
+                        'Europe/Berlin',
+                        new TZDate('2018-07-05T18:24:00.052Z'),
+                        false,
+                        true,
+                    ),
+                    '20180705T202400',
+                );
+            });
+            it('timezone=1 dateonly=1 floating=0', function () {
+                assert.strictEqual(
+                    formatDate(
+                        'Europe/Berlin',
+                        new TZDate('2018-07-05T18:24:00.052Z'),
+                        true,
+                        false,
+                    ),
+                    '20180705',
+                );
+            });
+            it('timezone=1 dateonly=1 floating=1', function () {
+                assert.strictEqual(
+                    formatDate(
+                        'Europe/Berlin',
+                        new TZDate('2018-07-05T18:24:00.052'),
+                        true,
+                        true,
+                    ),
+                    '20180705',
+                );
+            });
+            it('should work with / prefixed global timezones', function () {
+                assert.strictEqual(
+                    formatDate(
+                        '/Europe/Berlin',
+                        new TZDate('2018-07-05T18:24:00.052Z'),
+                        false,
+                        false,
+                    ),
+                    '20180705T202400',
+                );
+            });
+            it('should ignore TZDate timezone', function () {
+                assert.strictEqual(
+                    formatDate(
+                        null,
+                        new TZDate(
+                            '2018-07-05T18:24:00.052+02:00',
+                            'Europe/Berlin',
+                        ),
+                        false,
+                        false,
+                    ),
+                    '20180705T162400Z',
+                );
+            });
+            it('should work prefer timezone argument over TZDate timezone', function () {
+                assert.strictEqual(
+                    formatDate(
+                        'Europe/Berlin',
+                        new TZDate(
+                            '2018-07-05T18:24:00.052+02:00',
+                            'Asia/Tokyo',
+                        ),
                         false,
                         false,
                     ),


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - It adds a support to TZDate in the formatDate function so that timezone is correctly handled.
- **What is the current behavior?** (You can also link to an open issue here)
    - Currently formatDate treats TZDate as a normal Date. Date.getHours() returns the hour of the system timezone while TZDate.getHours() returns the hours of the given timezone.
- **What is the new behavior (if this is a feature change)?**
    - Passing in a TZDate to formatDate works correctly according to timezone.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - No breakage
- **Other information**:
    - Also added a "prepare" script to package json that allows the package to be directly depended on via github.


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [x] My change requires a change to the documentation
    - [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
