### PR TITLE
Add support for X-APPLE-CALENDAR-COLOR

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -26,6 +26,7 @@ export enum ICalCalendarMethod {
 }
 
 export interface ICalCalendarData {
+    color?: null | string;
     description?: null | string;
     events?: (ICalEvent | ICalEventData)[];
     method?: ICalCalendarMethod | null;
@@ -43,6 +44,7 @@ export interface ICalCalendarData {
 }
 
 export interface ICalCalendarJSONData {
+    color: null | string;
     description: null | string;
     events: ICalEventJSONData[];
     method: ICalCalendarMethod | null;
@@ -63,6 +65,7 @@ export interface ICalCalendarProdIdData {
 }
 
 interface ICalCalendarInternalData {
+    color: null | string;
     description: null | string;
     events: ICalEvent[];
     method: ICalCalendarMethod | null;
@@ -128,6 +131,7 @@ export default class ICalCalendar {
      */
     constructor(data: ICalCalendarData = {}) {
         this.data = {
+            color: null,
             description: null,
             events: [],
             method: null,
@@ -150,6 +154,7 @@ export default class ICalCalendar {
         if (data.url !== undefined) this.url(data.url);
         if (data.scale !== undefined) this.scale(data.scale);
         if (data.ttl !== undefined) this.ttl(data.ttl);
+        if (data.color !== undefined) this.color(data.color);
         if (data.events !== undefined) this.events(data.events);
         if (data.x !== undefined) this.x(data.x);
     }
@@ -165,6 +170,30 @@ export default class ICalCalendar {
         return this;
     }
 
+    /**
+     * Get your feed's color
+     * @returns {null|string}
+     */
+    color(): null | string;
+    /**
+     * Set your feed's color
+     * (Only supported on Apple calendar clients)
+     * @param {null|string} color \# followed by six character hex color code
+     */
+    color(color: null | string): this;
+    color(color?: null | string): null | string | this {
+        if (color === undefined) {
+            return this.data.color;
+        }
+
+        // Only six character hex color codes seem to be supported
+        if (typeof color === 'string' && !/^#[A-F0-9]{6}$/gi.test(color)) {
+            throw new Error('`color` is malformed!');
+        }
+
+        this.data.color = color ? String(color).toUpperCase() : null;
+        return this;
+    }
     /**
      * Creates a new {@link ICalEvent} and returns it. Use options to prefill the event's attributes.
      * Calling this method without options will create an empty event.
@@ -640,6 +669,11 @@ export default class ICalCalendar {
                 toDurationString(this.data.ttl) +
                 '\r\n';
             g += 'X-PUBLISHED-TTL:' + toDurationString(this.data.ttl) + '\r\n';
+        }
+
+        // Apple calendar color
+        if (this.data.color) {
+            g += 'X-APPLE-CALENDAR-COLOR:' + this.data.color + '\r\n';
         }
 
         // Events

--- a/test/calendar.ts
+++ b/test/calendar.ts
@@ -14,6 +14,7 @@ describe('ical-generator Calendar', function () {
     describe('constructor()', function () {
         it('shoud load json export', function () {
             const data: ICalCalendarJSONData = {
+                color: null,
                 description: 'Hi, I am the description.',
                 events: [],
                 method: ICalCalendarMethod.PUBLISH,
@@ -325,6 +326,30 @@ describe('ical-generator Calendar', function () {
                 summary: 'Example Event',
             });
             assert.ok(cal.scale(), 'GREGORIAN');
+        });
+    });
+
+    describe('color()', function () {
+        it('setter should return this', function () {
+            const cal = new ICalCalendar();
+            assert.deepStrictEqual(cal, cal.color('#237fcb'));
+        });
+
+        it('getter should return value', function () {
+            const cal = new ICalCalendar();
+            assert.strictEqual(cal.color(), null);
+            cal.color('#237fcb');
+            assert.strictEqual(cal.color(), '#237FCB');
+            cal.color(null);
+            assert.strictEqual(cal.color(), null);
+        });
+
+        it('should throw error when the color is formatted incorrectly', function () {
+            const cal = new ICalCalendar();
+            assert.throws(() => {
+                // @ts-ignore
+                cal.color('#fff');
+            });
         });
     });
 


### PR DESCRIPTION
### About this Pull Request
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Feature
- **What is the current behavior?** (You can also link to an open issue here)
    - Setting X-APPLE-CALENDAR-COLOR is not yet included as a standalone function, it is already supported by calendar.x() though
- **What is the new behavior (if this is a feature change)?**
    - Makes setting a calendar color easier and features it more prominently
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
    - Shouldn't break anything
- **Other information**:
    - I only found a calendar color attribute for Apple's calendar clients (tested iOS and macOS). Google Calendar seems to only allow setting colors via API and not via X-… attributes. Don't use Outlook so I didn't test if there is a custom color attribute for MS products.


### Pull Request Checklist

- [x] My code follows the code style of this project
    - Run `npm run lint` to double check
- [x] My change requires a change to the documentation
    - [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
    - Run `npm run test` to run the unit tests and `npm run coverage` to generate a coverage report
- [x] All new and existing tests passed
- [x] My commit messages follow the [commit guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
