### PR TITLE
fix(types): declare types entry for ESM consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "engines": {
         "node": "20 || 22 || >=24"
     },
+    "types": "./dist/index.d.mts",
     "exports": {
+        "types": "./dist/index.d.mts",
         "import": "./dist/index.mjs",
         "require": "./dist/index.cjs"
     },


### PR DESCRIPTION
## Problem

Under modern TypeScript / tsgo (Go-rewritten compiler), packages with `"type": "module"` and no explicit `"types"` field or `exports.types` condition fail to resolve types because the legacy sibling-`.d.ts` fallback is being removed.

This package currently has no `"types"` field, causing TypeScript consumers to see implicit-`any` when importing.

## Fix

Two lines added to `package.json`:
1. A top-level `"types": "./dist/index.d.mts"` field
2. A `"types"` condition first in the `exports` map

Both point at the `.d.mts` declaration file the package already ships in `dist/`.

## Impact

- No behavioral change — pure manifest fix
- TypeScript / tsgo consumers can now resolve types deterministically
- Both ESM (tsdown output) and CJS consumers benefit from the same declaration