### PR TITLE
fix(attendee): escape double quote in attendee SENT-BY parameter value

### DIFF
--- a/src/attendee.ts
+++ b/src/attendee.ts
@@ -543,7 +543,7 @@ export default class ICalAttendee {
 
         // SENT-BY
         if (this.data.sentBy !== null) {
-            g += ';SENT-BY="mailto:' + this.data.sentBy + '"';
+            g += ';SENT-BY="mailto:' + escape(this.data.sentBy, true) + '"';
         }
 
         // DELEGATED-TO

--- a/test/attendee.ts
+++ b/test/attendee.ts
@@ -173,6 +173,23 @@ describe('ical-generator Attendee', function () {
             );
             assert.ok(a.toString().includes('bar@example.com'));
         });
+
+        it('should escape the double quote in the quoted parameter value', function () {
+            const a = new ICalAttendee(
+                {
+                    email: 'foo@example.com',
+                    sentBy: 'bar@example.com" X-EVIL:injected',
+                },
+                new ICalEvent({ start: new Date() }, new ICalCalendar()),
+            );
+            assert.ok(
+                a
+                    .toString()
+                    .includes(
+                        ';SENT-BY="mailto:bar@example.com X-EVIL:injected"',
+                    ),
+            );
+        });
     });
 
     describe('role()', function () {


### PR DESCRIPTION
The attendee generator writes the `SENT-BY` value straight into the quoted parameter without escaping it:

```ts
g += ';SENT-BY="mailto:' + this.data.sentBy + '"';
```

`sentBy()` accepts an arbitrary string, so a value that contains a double quote closes the quoted parameter early and the remainder leaks into the line as extra parameters/content. For example `attendee.sentBy('bar@example.com" X-EVIL:injected')` currently renders:

```
ATTENDEE;ROLE=REQ-PARTICIPANT;SENT-BY="mailto:bar@example.com" X-EVIL:injected":MAILTO:foo@example.com
```

The organizer generator already escapes the same parameter (`src/event.ts`):

```ts
';SENT-BY="mailto:' + escape(this.data.organizer.sentBy, true) + '"'
```

and the attendee's own `CN` parameter a few lines below already uses `escape(value, true)`. This change makes attendee `SENT-BY` consistent with both, so the double quote is stripped and the value stays inside the parameter:

```
ATTENDEE;ROLE=REQ-PARTICIPANT;SENT-BY="mailto:bar@example.com X-EVIL:injected":MAILTO:foo@example.com
```

I added a test under `sentBy()` that fails on the current output and passes with the change. The full suite stays green.
